### PR TITLE
[codex] 支持主窗口快捷键聚焦输入框并切换显示状态

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -18,9 +18,11 @@ use crate::models::{
     CaptureRect, CaptureTranslatePayload, CaptureViewPayload, HistoryQuery, OverlayPayload,
     SelectionPayload, TextTranslationResult, TranslationHistoryItem, TranslatorSettings,
 };
+use crate::popup_shortcut::{decide_popup_shortcut_action, PopupShortcutAction};
 
 const OVERLAY_WINDOW_LABEL: &str = "overlay";
 const CAPTURE_WINDOW_LABEL: &str = "capture";
+const FOCUS_TEXT_INPUT_EVENT: &str = "main:focus-text-input";
 const WIN_WIDTH: f64 = 520.0;
 
 // ── Settings ────────────────────────────────────────────────────────────────
@@ -113,13 +115,7 @@ pub fn apply_popup_shortcut(app: &AppHandle, shortcut: &str) {
             if event.state == ShortcutState::Pressed {
                 let app2 = app_clone.clone();
                 tauri::async_runtime::spawn(async move {
-                    #[cfg(target_os = "macos")]
-                    let _ = app2.set_dock_visibility(true);
-                    if let Some(w) = app2.get_webview_window("main") {
-                        let _ = w.unminimize();
-                        let _ = w.show();
-                        let _ = w.set_focus();
-                    }
+                    let _ = toggle_main_window_from_popup_shortcut(&app2);
                 });
             }
         })
@@ -200,6 +196,32 @@ fn instant_hide(window: &tauri::WebviewWindow) {
         }
     }
     let _ = window.hide();
+}
+
+fn toggle_main_window_from_popup_shortcut(app: &AppHandle) -> AppResult<()> {
+    let Some(window) = app.get_webview_window("main") else {
+        return Ok(());
+    };
+
+    let is_visible = window.is_visible().unwrap_or(false);
+    match decide_popup_shortcut_action(is_visible) {
+        PopupShortcutAction::HideWindow => {
+            instant_hide(&window);
+            #[cfg(target_os = "macos")]
+            app.set_dock_visibility(false)?;
+        }
+        PopupShortcutAction::ShowWindowAndFocusInput => {
+            #[cfg(target_os = "macos")]
+            app.set_dock_visibility(true)?;
+            let _ = window.unminimize();
+            let _ = window.show();
+            let _ = window.set_focus();
+            // 显示窗口由后端负责，真正聚焦哪个输入控件交给前端决定，避免后端耦合 DOM 细节。
+            app.emit_to("main", FOCUS_TEXT_INPUT_EVENT, serde_json::json!({}))?;
+        }
+    }
+
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,6 +9,7 @@ mod commands;
 mod config;
 mod error;
 mod models;
+mod popup_shortcut;
 mod self_test;
 mod translate_engine;
 

--- a/src-tauri/src/popup_shortcut.rs
+++ b/src-tauri/src/popup_shortcut.rs
@@ -1,0 +1,35 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PopupShortcutAction {
+    HideWindow,
+    ShowWindowAndFocusInput,
+}
+
+pub fn decide_popup_shortcut_action(main_window_visible: bool) -> PopupShortcutAction {
+    // 将快捷键行为决策提取成纯函数，便于单测并避免窗口逻辑分支散落在事件回调里。
+    if main_window_visible {
+        PopupShortcutAction::HideWindow
+    } else {
+        PopupShortcutAction::ShowWindowAndFocusInput
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PopupShortcutAction, decide_popup_shortcut_action};
+
+    #[test]
+    fn hides_window_when_main_window_is_visible() {
+        assert_eq!(
+            decide_popup_shortcut_action(true),
+            PopupShortcutAction::HideWindow
+        );
+    }
+
+    #[test]
+    fn shows_window_and_focuses_input_when_main_window_is_hidden() {
+        assert_eq!(
+            decide_popup_shortcut_action(false),
+            PopupShortcutAction::ShowWindowAndFocusInput
+        );
+    }
+}

--- a/ui/app.js
+++ b/ui/app.js
@@ -1,3 +1,5 @@
+import { focusTextInputIfAllowed } from "./focus-helpers.mjs";
+
 const LANGUAGES = [
   { value: "auto", label: "自动检测" },
   { value: "zh-CHS", label: "中文简体" },
@@ -154,6 +156,13 @@ async function bindMainListeners() {
       setCapturePreparing(false);
     }
     updateOutputArea();
+  });
+  await listen("main:focus-text-input", () => {
+    focusTextInputIfAllowed({
+      mode,
+      hotkeyRecording: state.hotkeyRecording,
+      input: document.querySelector("#text-input"),
+    });
   });
   state.listenersBound = true;
 }

--- a/ui/focus-helpers.mjs
+++ b/ui/focus-helpers.mjs
@@ -1,0 +1,24 @@
+export function shouldAutoFocusTextInput({ mode, hotkeyRecording }) {
+  return mode === "main" && !hotkeyRecording;
+}
+
+export function focusTextInputIfAllowed({ mode, hotkeyRecording, input }) {
+  if (!shouldAutoFocusTextInput({ mode, hotkeyRecording })) {
+    return false;
+  }
+
+  if (!input || typeof input.focus !== "function") {
+    return false;
+  }
+
+  input.focus({ preventScroll: true });
+
+  // 呼出窗口后把光标放到末尾，用户可以直接继续输入或追加内容。
+  const value = typeof input.value === "string" ? input.value : "";
+  if (typeof input.setSelectionRange === "function") {
+    const caret = value.length;
+    input.setSelectionRange(caret, caret);
+  }
+
+  return true;
+}

--- a/ui/focus-helpers.test.mjs
+++ b/ui/focus-helpers.test.mjs
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { focusTextInputIfAllowed, shouldAutoFocusTextInput } from "./focus-helpers.mjs";
+
+test("主窗口且未录制快捷键时允许自动聚焦", () => {
+  assert.equal(
+    shouldAutoFocusTextInput({ mode: "main", hotkeyRecording: false }),
+    true,
+  );
+});
+
+test("录制快捷键时不自动聚焦", () => {
+  assert.equal(
+    shouldAutoFocusTextInput({ mode: "main", hotkeyRecording: true }),
+    false,
+  );
+});
+
+test("非主窗口模式不自动聚焦", () => {
+  assert.equal(
+    shouldAutoFocusTextInput({ mode: "overlay", hotkeyRecording: false }),
+    false,
+  );
+});
+
+test("允许自动聚焦时将焦点放到输入框末尾", () => {
+  const calls = [];
+  const input = {
+    value: "hello",
+    focus(options) {
+      calls.push(["focus", options]);
+    },
+    setSelectionRange(start, end) {
+      calls.push(["setSelectionRange", start, end]);
+    }
+  };
+
+  const focused = focusTextInputIfAllowed({
+    mode: "main",
+    hotkeyRecording: false,
+    input,
+  });
+
+  assert.equal(focused, true);
+  assert.deepEqual(calls, [
+    ["focus", { preventScroll: true }],
+    ["setSelectionRange", 5, 5],
+  ]);
+});
+
+test("没有输入框时安全跳过", () => {
+  const focused = focusTextInputIfAllowed({
+    mode: "main",
+    hotkeyRecording: false,
+    input: null,
+  });
+
+  assert.equal(focused, false);
+});


### PR DESCRIPTION
﻿## 变更内容
- 支持使用主窗口快捷键呼出应用后自动聚焦到文本输入框，可直接键盘输入翻译文本
- 支持再次按下同一个主窗口快捷键时直接隐藏主窗口
- 新增前端聚焦辅助逻辑与对应自动化测试，确保聚焦行为不会干扰快捷键录制

## 变更原因
- 之前主窗口快捷键只能显示窗口，呼出后仍需要手动点击输入框，键盘流转不顺畅
- 同一个快捷键无法完成显示与隐藏切换，频繁使用时操作成本偏高

## 影响范围
- 主窗口快捷键交互改为切换显示状态
- 主窗口被快捷键呼出时会把焦点移动到文本输入框末尾
- 截图快捷键语义保持不变

## 根因
- 后端弹出快捷键处理只负责显示窗口，没有切换显示/隐藏状态的决策逻辑
- 前端缺少独立的输入框聚焦事件处理，因此窗口显示后无法稳定将焦点落到目标输入控件

## 验证
- `node --test ui\focus-helpers.test.mjs`
- `cargo build --release`
