### PR TITLE
fix(capture): Windows 截图后 spinner 一直转圈，无翻译结果

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -386,6 +386,19 @@ async fn begin_capture_impl(app: &AppHandle, state: &SharedState) -> AppResult<(
             rgba.len() as f64 / 1_048_576.0
         );
 
+        *state.capture_session.write().await = Some(crate::app_state::ActiveCaptureSession {
+            rgba: rgba.clone(),
+            img_w: w,
+            img_h: h,
+            scale_factor,
+            monitor_x: monitor.x,
+            monitor_y: monitor.y,
+            monitor_width: monitor.width,
+            monitor_height: monitor.height,
+            preview_image_base64: None,
+            preview_image_mime: String::new(),
+        });
+
         let (event_tx, event_rx) = mpsc::channel::<CaptureEvent>();
         capture_window::start_capture(rgba.clone(), w, h, scale_factor, monitor.x, monitor.y, event_tx);
         tracing::info!("[PERF] start_capture_native: {:?}", t0.elapsed());
@@ -578,6 +591,8 @@ async fn handle_capture_events(
                     Err(e) => {
                         tracing::error!("Translation error: {e}");
                         emit_workflow_state(&app, "翻译失败", "error", false).ok();
+                        let _ = capture_window::capture_proxy().send_event(CaptureCommand::Close);
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
## 现象

在 Windows 下用快捷键截图，框选完区域后 spinner 一直转圈，永远不出翻译结果，必须按 ESC 才能退出。

## 根因

多显示器支持（commit 3e5e3a3）把 `translate_capture_png` 改成了从 `state.capture_session` 读 `monitor_x/y/width/height`，但只更新了 `begin_capture_impl` 的 macOS 分支去**写入** `capture_session`，**Windows/Linux 分支从未写过**。

所以非 macOS 平台每次选区都立刻报：

\`\`\`
AppError::Capture("capture session missing")
\`\`\`

而 native 截图窗口的 spinner 没有任何指令能停止 —— `ShowResult` 永远不会发，于是 spinner 一直转。错误只通过 `tracing::error!` + 隐藏的主窗口的 `workflow:state` 事件透出来，用户看不见。

## 修复

1. **主修复** —— 在 `begin_capture_impl` 的 `#[cfg(not(target_os = \"macos\"))]` 分支同步写入 `state.capture_session`，与 macOS 分支对齐。
2. **防御性修复** —— 在 `handle_capture_events` 的翻译错误分支发送 `CaptureCommand::Close` 并 `break` 事件循环，避免以后任何翻译失败（网络、API 异常等）让 spinner 卡死。

## 测试

在 Windows x64 上用 fork 的 CI 出包验证：截图 → 选区 → 看到结果图正常覆盖到选区位置。