### PR TITLE
feat: 截图翻译支持右键切换原文/译文

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,10 +11,13 @@ tauri-build = { version = "2.0.1", features = [] }
 arboard = "3"
 base64 = "0.22.1"
 chrono = { version = "0.4.40", features = ["serde"] }
+hmac = "0.12"
 image = { version = "0.25.5", default-features = false, features = ["png", "jpeg", "bmp"] }
 md5 = "0.7.0"
+percent-encoding = "2"
 reqwest = { version = "0.12.12", default-features = false, features = ["json", "multipart", "native-tls"] }
 screenshots = "0.8.10"
+sha2 = "0.10"
 softbuffer = "0.4"
 winit = { version = "0.30", features = ["rwh_06"] }
 serde = { version = "1.0.217", features = ["derive"] }
@@ -32,6 +35,9 @@ uuid = { version = "1.12.1", features = ["serde", "v4"] }
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.25"
 objc2-app-kit = { version = "0.2.2", features = ["NSWindow", "NSEvent"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+winreg = "0.55"
 
 [features]
 default = []

--- a/src-tauri/src/builtin_translate.rs
+++ b/src-tauri/src/builtin_translate.rs
@@ -1,0 +1,532 @@
+//! Built-in, key-free text translation engines ported from STranslate's
+//! `*BuiltIn` plugins. None of these require the user to provide an API key;
+//! they authenticate via baked-in client identifiers / signatures / tokens,
+//! the same technique the Youdao image-translation endpoint already uses.
+//!
+//! Providers:
+//! - Google   : `translate.googleapis.com` free `gtx` endpoint
+//! - Microsoft: Edge auth token + `api-edge.cognitive.microsofttranslator.com`
+//! - Transmart: Tencent `transmart.qq.com/api/imt` (hard-coded client_key)
+//! - Yandex   : `translate.yandex.net` mobile endpoint (baked-in ucid)
+//! - iCiba    : `dictionary.iciba.com/dictionary/fy/batch` (client/key + MD5 sign)
+
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
+use chrono::Utc;
+use hmac::{Hmac, Mac};
+use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
+use reqwest::header::{HeaderMap, HeaderValue, ORIGIN, REFERER, USER_AGENT};
+use reqwest::Client;
+use sha2::Sha256;
+use tokio::sync::RwLock;
+
+use crate::error::{AppError, AppResult};
+use crate::models::TextTranslationResult;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Matches C#'s `Uri.EscapeDataString`: escape everything except the unreserved
+/// set A-Za-z0-9 and `-` `_` `.` `~`.
+const ESCAPE_SET: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'_')
+    .remove(b'.')
+    .remove(b'~');
+
+/// Microsoft "MSTranslatorAndroidApp" HMAC signing key (from GTranslate / STranslate).
+const MS_PRIVATE_KEY: [u8; 64] = [
+    0xa2, 0x29, 0x3a, 0x3d, 0xd0, 0xdd, 0x32, 0x73, 0x97, 0x7a, 0x64, 0xdb, 0xc2, 0xf3, 0x27, 0xf5,
+    0xd7, 0xbf, 0x87, 0xd9, 0x45, 0x9d, 0xf0, 0x5a, 0x09, 0x66, 0xc6, 0x30, 0xc6, 0x6a, 0xaa, 0x84,
+    0x9a, 0x41, 0xaa, 0x94, 0x3a, 0xa8, 0xd5, 0x1a, 0x6e, 0x4d, 0xaa, 0xc9, 0xa3, 0x70, 0x12, 0x35,
+    0xc7, 0xeb, 0x12, 0xf6, 0xe8, 0x23, 0x07, 0x9e, 0x47, 0x10, 0x95, 0x91, 0x88, 0x55, 0xd8, 0x17,
+];
+const MS_ENDPOINT: &str = "api.cognitive.microsofttranslator.com";
+
+const YANDEX_USER_AGENT: &str = "ru.yandex.translate/3.20.2024";
+const BROWSER_UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+                          (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36";
+
+// iCiba batch-translate signing constants (from STranslate ICibaTranslateBuiltIn).
+const ICIBA_PATH: &str = "/dictionary/fy/batch";
+const ICIBA_CLIENT: &str = "6";
+const ICIBA_KEY: &str = "1000006";
+const ICIBA_SALT: &str = "7ece94d9f9c202b0d2ec557dg4r9bc";
+
+pub struct BuiltinTranslateClient {
+    /// Cached HTTP client keyed by its proxy URL ("" = no proxy). Rebuilt
+    /// on demand whenever the effective proxy configuration changes.
+    cache: RwLock<Option<(String, Client)>>,
+}
+
+impl BuiltinTranslateClient {
+    pub fn new() -> Self {
+        Self {
+            cache: RwLock::new(None),
+        }
+    }
+
+    /// Return an HTTP client configured for the given proxy URL (None = direct),
+    /// reusing the cached one when the proxy setting is unchanged. The client
+    /// has NO default User-Agent so each provider can set its own per request.
+    async fn client(&self, proxy: Option<&str>) -> Client {
+        let key = proxy.unwrap_or("").to_string();
+        {
+            let guard = self.cache.read().await;
+            if let Some((cached_key, client)) = guard.as_ref() {
+                if cached_key == &key {
+                    return client.clone();
+                }
+            }
+        }
+
+        let mut builder = Client::builder();
+        match proxy {
+            Some(url) if !url.is_empty() => {
+                if let Ok(p) = reqwest::Proxy::all(url) {
+                    builder = builder.proxy(p);
+                }
+            }
+            // Explicitly disable proxies (ignore env vars) when direct is chosen.
+            _ => builder = builder.no_proxy(),
+        }
+        let client = builder.build().unwrap_or_else(|_| Client::new());
+        *self.cache.write().await = Some((key, client.clone()));
+        client
+    }
+
+    // ── Google (free gtx endpoint) ─────────────────────────────────────────
+    pub async fn google(
+        &self,
+        text: &str,
+        from: &str,
+        to: &str,
+        proxy: Option<&str>,
+    ) -> AppResult<TextTranslationResult> {
+        let sl = google_lang(from);
+        let tl = google_lang(to);
+
+        let resp = self
+            .client(proxy)
+            .await
+            .get("https://translate.googleapis.com/translate_a/single")
+            .header(USER_AGENT, BROWSER_UA)
+            .query(&[
+                ("client", "gtx"),
+                ("sl", sl.as_str()),
+                ("tl", tl.as_str()),
+                ("dt", "t"),
+                ("q", text),
+            ])
+            .send()
+            .await
+            .map_err(|e| AppError::Api(format!("Google translate request failed: {e}")))?
+            .error_for_status()
+            .map_err(|e| AppError::Api(format!("Google translate http error: {e}")))?;
+
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| AppError::Api(format!("Google translate parse failed: {e}")))?;
+
+        let mut translated = String::new();
+        if let Some(segments) = body.get(0).and_then(|v| v.as_array()) {
+            for seg in segments {
+                if let Some(part) = seg.get(0).and_then(|v| v.as_str()) {
+                    translated.push_str(part);
+                }
+            }
+        }
+        let detected = body
+            .get(2)
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| from.to_string());
+
+        finalize(translated, detected, "Google")
+    }
+
+    // ── Microsoft (MSTranslatorAndroidApp signature, no token needed) ──────
+    pub async fn microsoft(
+        &self,
+        text: &str,
+        from: &str,
+        to: &str,
+        proxy: Option<&str>,
+    ) -> AppResult<TextTranslationResult> {
+        let from_ms = microsoft_lang(from);
+        let to_ms = microsoft_lang(to);
+
+        // Build the request path (without protocol); it is used both as the POST
+        // URL and as the signed content, so the two must match exactly.
+        let mut request_path = format!("{MS_ENDPOINT}/translate?api-version=3.0&to={to_ms}");
+        if !from_ms.is_empty() && from_ms != "auto" {
+            request_path.push_str(&format!("&from={from_ms}"));
+        }
+
+        let signature = ms_signature(&request_path);
+
+        let resp = self
+            .client(proxy)
+            .await
+            .post(format!("https://{request_path}"))
+            .header("X-MT-Signature", signature)
+            .header(USER_AGENT, BROWSER_UA)
+            .json(&[serde_json::json!({ "Text": text })])
+            .send()
+            .await
+            .map_err(|e| AppError::Api(format!("Microsoft translate request failed: {e}")))?;
+
+        let body: serde_json::Value = resp
+            .error_for_status()
+            .map_err(|e| AppError::Api(format!("Microsoft translate http error: {e}")))?
+            .json()
+            .await
+            .map_err(|e| AppError::Api(format!("Microsoft translate parse failed: {e}")))?;
+
+        let translated = body
+            .pointer("/0/translations/0/text")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let detected = body
+            .pointer("/0/detectedLanguage/language")
+            .and_then(|v| v.as_str())
+            .unwrap_or(from)
+            .to_string();
+
+        finalize(translated, detected, "Microsoft")
+    }
+
+    // ── Tencent Transmart ──────────────────────────────────────────────────
+    pub async fn transmart(
+        &self,
+        text: &str,
+        from: &str,
+        to: &str,
+        proxy: Option<&str>,
+    ) -> AppResult<TextTranslationResult> {
+        let source = transmart_lang(from);
+        let target = transmart_lang(to);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(USER_AGENT, HeaderValue::from_static(
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 \
+             (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36",
+        ));
+        headers.insert(REFERER, HeaderValue::from_static("https://yi.qq.com/zh-CN/index"));
+
+        let payload = serde_json::json!({
+            "header": {
+                "fn": "auto_translation_block",
+                "client_key": "browser-chrome-110.0.0-Mac OS-df4bd4c5-a65d-44b2-a40f-42f34f3535f2-1677486696487"
+            },
+            "type": "plain",
+            "model_category": "normal",
+            "source": { "lang": source, "text_block": text },
+            "target": { "lang": target }
+        });
+
+        let body: serde_json::Value = self
+            .client(proxy)
+            .await
+            .post("https://transmart.qq.com/api/imt")
+            .headers(headers)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| AppError::Api(format!("Transmart request failed: {e}")))?
+            .error_for_status()
+            .map_err(|e| AppError::Api(format!("Transmart http error: {e}")))?
+            .json()
+            .await
+            .map_err(|e| AppError::Api(format!("Transmart parse failed: {e}")))?;
+
+        // `auto_translation` may be a string or an array of blocks.
+        let translated = match body.get("auto_translation") {
+            Some(serde_json::Value::String(s)) => s.clone(),
+            Some(serde_json::Value::Array(arr)) => arr
+                .iter()
+                .filter_map(|v| v.as_str())
+                .collect::<Vec<_>>()
+                .join("\n"),
+            _ => String::new(),
+        };
+
+        finalize(translated, from.to_string(), "Transmart")
+    }
+
+    // ── Yandex ─────────────────────────────────────────────────────────────
+    pub async fn yandex(
+        &self,
+        text: &str,
+        from: &str,
+        to: &str,
+        proxy: Option<&str>,
+    ) -> AppResult<TextTranslationResult> {
+        let src = yandex_lang(from);
+        let tgt = yandex_lang(to);
+        // Yandex rejects "auto-<tgt>"; for auto-detect send only the target code.
+        let lang = if src == "auto" {
+            tgt.clone()
+        } else {
+            format!("{src}-{tgt}")
+        };
+        let ucid = uuid::Uuid::new_v4().simple().to_string();
+
+        let url = format!(
+            "https://translate.yandex.net/api/v1/tr.json/translate?ucid={ucid}&srv=android&format=text"
+        );
+
+        let body: serde_json::Value = self
+            .client(proxy)
+            .await
+            .post(&url)
+            .header(USER_AGENT, YANDEX_USER_AGENT)
+            .form(&[("text", text), ("lang", lang.as_str())])
+            .send()
+            .await
+            .map_err(|e| AppError::Api(format!("Yandex request failed: {e}")))?
+            .error_for_status()
+            .map_err(|e| AppError::Api(format!("Yandex http error: {e}")))?
+            .json()
+            .await
+            .map_err(|e| AppError::Api(format!("Yandex parse failed: {e}")))?;
+
+        let translated = body
+            .get("text")
+            .and_then(|v| v.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        finalize(translated, from.to_string(), "Yandex")
+    }
+
+    // ── iCiba (Kingsoft) batch translate ───────────────────────────────────
+    pub async fn iciba(
+        &self,
+        text: &str,
+        from: &str,
+        to: &str,
+        proxy: Option<&str>,
+    ) -> AppResult<TextTranslationResult> {
+        let from_ic = iciba_lang(from);
+        let to_ic = iciba_lang(to);
+        let timestamp = chrono::Utc::now().timestamp_millis().to_string();
+
+        // signature = md5(path + concat(values sorted by key) + salt)
+        // sorted keys (Ordinal): client < key < timestamp
+        let sign_src = format!(
+            "{ICIBA_PATH}{ICIBA_CLIENT}{ICIBA_KEY}{timestamp}{ICIBA_SALT}"
+        );
+        let signature = format!("{:x}", md5::compute(sign_src.as_bytes()));
+
+        let mut headers = HeaderMap::new();
+        headers.insert(ORIGIN, HeaderValue::from_static("https://www.iciba.com"));
+        headers.insert(REFERER, HeaderValue::from_static("https://www.iciba.com/"));
+        headers.insert(USER_AGENT, HeaderValue::from_static(BROWSER_UA));
+
+        let payload = serde_json::json!({
+            "from": from_ic,
+            "to": to_ic,
+            "textList": [text],
+        });
+
+        let body: serde_json::Value = self
+            .client(proxy)
+            .await
+            .post("https://dictionary.iciba.com/dictionary/fy/batch")
+            .query(&[
+                ("client", ICIBA_CLIENT),
+                ("key", ICIBA_KEY),
+                ("timestamp", timestamp.as_str()),
+                ("signature", signature.as_str()),
+            ])
+            .headers(headers)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| AppError::Api(format!("iCiba request failed: {e}")))?
+            .error_for_status()
+            .map_err(|e| AppError::Api(format!("iCiba http error: {e}")))?
+            .json()
+            .await
+            .map_err(|e| AppError::Api(format!("iCiba parse failed: {e}")))?;
+
+        let code_ok = match body.get("code") {
+            Some(serde_json::Value::Number(n)) => n.as_i64() == Some(1),
+            Some(serde_json::Value::String(s)) => s == "1",
+            _ => false,
+        };
+        if !code_ok {
+            return Err(AppError::Api(format!("iCiba error: {body}")));
+        }
+
+        let mut lines = Vec::new();
+        if let Some(arr) = body.get("data").and_then(|v| v.as_array()) {
+            for item in arr {
+                match item {
+                    serde_json::Value::String(s) if !s.is_empty() => lines.push(s.clone()),
+                    serde_json::Value::Object(_) => {
+                        if let Some(out) = item.get("out").and_then(|v| v.as_str()) {
+                            if !out.is_empty() {
+                                lines.push(out.to_string());
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        finalize(lines.join("\n"), from.to_string(), "iCiba")
+    }
+}
+
+fn finalize(
+    translated: String,
+    detected: String,
+    engine: &str,
+) -> AppResult<TextTranslationResult> {
+    if translated.trim().is_empty() {
+        return Err(AppError::Api(format!("{engine} returned empty result")));
+    }
+    Ok(TextTranslationResult {
+        translated_text: translated,
+        from_lang_detected: detected,
+        alternatives: Vec::new(),
+    })
+}
+
+/// Build the `X-MT-Signature` header value for the Microsoft "android app"
+/// free endpoint. `request_path` is the URL without the `https://` prefix.
+fn ms_signature(request_path: &str) -> String {
+    let guid = uuid::Uuid::new_v4().simple().to_string(); // 32 lowercase hex
+    let escaped_url = utf8_percent_encode(request_path, ESCAPE_SET).to_string();
+    // e.g. "Sun, 12 Jul 2026 15:35:39GMT"
+    let date_time = format!("{}GMT", Utc::now().format("%a, %d %b %Y %H:%M:%S"));
+
+    let raw = format!("MSTranslatorAndroidApp{escaped_url}{date_time}{guid}").to_lowercase();
+
+    let mut mac = HmacSha256::new_from_slice(&MS_PRIVATE_KEY).expect("HMAC key of valid length");
+    mac.update(raw.as_bytes());
+    let hash = mac.finalize().into_bytes();
+    let sig_b64 = BASE64_STANDARD.encode(hash);
+
+    format!("MSTranslatorAndroidApp::{sig_b64}::{date_time}::{guid}")
+}
+
+// ── Per-provider language code mapping (from Glance internal codes) ─────────
+
+fn google_lang(code: &str) -> String {
+    match code {
+        "auto" => "auto",
+        "zh-CHS" => "zh-CN",
+        "zh-CHT" => "zh-TW",
+        other => other,
+    }
+    .to_string()
+}
+
+fn microsoft_lang(code: &str) -> String {
+    match code {
+        "auto" => "auto",
+        "zh-CHS" => "zh-Hans",
+        "zh-CHT" => "zh-Hant",
+        other => other,
+    }
+    .to_string()
+}
+
+fn transmart_lang(code: &str) -> String {
+    match code {
+        "auto" => "auto",
+        "zh-CHS" => "zh",
+        "zh-CHT" => "zh-TW",
+        other => other,
+    }
+    .to_string()
+}
+
+fn yandex_lang(code: &str) -> String {
+    match code {
+        "auto" => "auto",
+        "zh-CHS" | "zh-CHT" => "zh",
+        other => other,
+    }
+    .to_string()
+}
+
+fn iciba_lang(code: &str) -> String {
+    match code {
+        "auto" => "auto",
+        "zh-CHS" => "zh",
+        "zh-CHT" => "cht",
+        other => other,
+    }
+    .to_string()
+}
+
+/// Read the Windows system proxy (as configured by proxy apps / Internet
+/// Settings). Returns an `http://host:port` URL usable by reqwest, or None.
+#[cfg(target_os = "windows")]
+pub fn system_proxy_url() -> Option<String> {
+    use winreg::enums::HKEY_CURRENT_USER;
+    use winreg::RegKey;
+
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let key = hkcu
+        .open_subkey(r"Software\Microsoft\Windows\CurrentVersion\Internet Settings")
+        .ok()?;
+    let enable: u32 = key.get_value("ProxyEnable").ok()?;
+    if enable == 0 {
+        return None;
+    }
+    let server: String = key.get_value("ProxyServer").ok()?;
+    if server.is_empty() {
+        return None;
+    }
+
+    // "ProxyServer" is either "host:port" or
+    // "http=host:port;https=host:port;socks=host:port".
+    if server.contains('=') {
+        let mut http_fallback = None;
+        for part in server.split(';') {
+            let mut kv = part.splitn(2, '=');
+            let scheme = kv.next().unwrap_or("").trim();
+            let addr = kv.next().unwrap_or("").trim();
+            if addr.is_empty() {
+                continue;
+            }
+            if scheme.eq_ignore_ascii_case("https") {
+                return Some(format!("http://{addr}"));
+            }
+            if scheme.eq_ignore_ascii_case("http") {
+                http_fallback = Some(format!("http://{addr}"));
+            }
+        }
+        http_fallback
+    } else {
+        Some(format!("http://{server}"))
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn system_proxy_url() -> Option<String> {
+    None
+}
+
+/// Normalize a user-supplied custom proxy string into a URL reqwest accepts.
+/// Bare `host:port` is assumed to be an HTTP proxy.
+pub fn normalize_proxy(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.contains("://") {
+        Some(trimmed.to_string())
+    } else {
+        Some(format!("http://{trimmed}"))
+    }
+}

--- a/src-tauri/src/capture_window.rs
+++ b/src-tauri/src/capture_window.rs
@@ -154,6 +154,10 @@ struct ResultOverlay {
     y: u32,
     w: u32,
     h: u32,
+    /// Whether the translated overlay is currently shown. When false, the
+    /// original (un-translated) screenshot region is shown instead, letting the
+    /// user toggle between original text and translation via right-click.
+    visible: bool,
 }
 
 struct CaptureHandler {
@@ -350,14 +354,43 @@ impl ApplicationHandler<CaptureCommand> for CaptureHandler {
                 }
             }
 
-            // Right-click to cancel capture.
+            // Right-click: when a translation result is shown and the cursor is
+            // inside the selected region, toggle between translation and original
+            // text. Otherwise, right-click cancels the capture.
+            //
+            // Handle this on Released (not Pressed): closing the window on the
+            // press would let the button-up event fall through to whatever window
+            // is now underneath, triggering its native context menu. Consuming
+            // both press and release here keeps the right-click fully contained.
             WindowEvent::MouseInput {
-                state: ElementState::Pressed,
+                state: ElementState::Released,
                 button: MouseButton::Right,
                 ..
             } => {
-                let _ = session.event_tx.send(CaptureEvent::Cancelled);
-                self.close_window();
+                let inside_result = session
+                    .result
+                    .is_some()
+                    .then(|| session.selection)
+                    .flatten()
+                    .map(|(sx, sy, sw, sh)| {
+                        let mx = session.mouse_pos.x;
+                        let my = session.mouse_pos.y;
+                        mx >= sx as f64
+                            && mx < (sx + sw) as f64
+                            && my >= sy as f64
+                            && my < (sy + sh) as f64
+                    })
+                    .unwrap_or(false);
+
+                if inside_result {
+                    if let Some(res) = &mut session.result {
+                        res.visible = !res.visible;
+                    }
+                    session.window.request_redraw();
+                } else {
+                    let _ = session.event_tx.send(CaptureEvent::Cancelled);
+                    self.close_window();
+                }
             }
 
             WindowEvent::CloseRequested => {
@@ -394,7 +427,7 @@ impl ApplicationHandler<CaptureCommand> for CaptureHandler {
             } => {
                 if let HandlerState::Selecting(session) = &mut self.state {
                     let pixels = rgba_to_softbuffer(&rgba_bytes);
-                    session.result = Some(ResultOverlay { pixels, x, y, w, h });
+                    session.result = Some(ResultOverlay { pixels, x, y, w, h, visible: true });
                     session.loading = false;
                     session.window.request_redraw();
                 }
@@ -445,21 +478,43 @@ fn redraw_session(session: &mut CaptureSession) {
     // Start with darkened screenshot.
     buffer.copy_from_slice(&session.darkened_pixels);
 
-    // If there's a result overlay, paint it on top.
+    // If there's a result overlay, paint the translation on top — or, when the
+    // user has toggled it off, show the original (un-darkened) screenshot region
+    // so they can read the source text. Right-click inside the region flips this.
+    // The selection border is drawn in both states so toggling never removes it.
     if let Some(ref res) = session.result {
-        // res.pixels is a compact res.w×res.h image — stride equals res.w, offset (0,0).
-        blit_pixels(
-            &mut buffer,
-            width,
-            &res.pixels,
-            res.w,
-            0,
-            0,
-            res.x,
-            res.y,
-            res.w,
-            res.h,
-        );
+        if res.visible {
+            // res.pixels is a compact res.w×res.h image — stride equals res.w, offset (0,0).
+            blit_pixels(
+                &mut buffer,
+                width,
+                &res.pixels,
+                res.w,
+                0,
+                0,
+                res.x,
+                res.y,
+                res.w,
+                res.h,
+            );
+        } else if let Some((sx, sy, sw, sh)) = session.selection {
+            // Show the original screenshot for the selected region (bright, not dimmed).
+            blit_pixels(
+                &mut buffer,
+                width,
+                &session.original_pixels,
+                session.img_w,
+                sx,
+                sy,
+                sx,
+                sy,
+                sw,
+                sh,
+            );
+        }
+        if let Some((sx, sy, sw, sh)) = session.selection {
+            draw_border(&mut buffer, width, height, sx, sy, sw, sh, 0x004A9EFF, 2);
+        }
         let _ = buffer.present();
         return;
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -191,13 +191,31 @@ pub async fn translate_text(
     from_lang: String,
     to_lang: String,
 ) -> AppResult<TextTranslationResult> {
-    let (engine, llm_config) = {
+    let (engine, llm_config, proxy_url) = {
         let settings = state.settings.read().await;
-        (settings.text_translate_engine, settings.llm_config.clone())
+        let proxy_url = match settings.proxy_mode {
+            crate::models::ProxyMode::None => None,
+            crate::models::ProxyMode::System => crate::builtin_translate::system_proxy_url(),
+            crate::models::ProxyMode::Custom => {
+                crate::builtin_translate::normalize_proxy(&settings.custom_proxy)
+            }
+        };
+        (
+            settings.text_translate_engine,
+            settings.llm_config.clone(),
+            proxy_url,
+        )
     };
     state
         .text_translator
-        .translate(&text, &from_lang, &to_lang, engine, &llm_config)
+        .translate(
+            &text,
+            &from_lang,
+            &to_lang,
+            engine,
+            &llm_config,
+            proxy_url.as_deref(),
+        )
         .await
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -225,7 +225,16 @@ pub async fn translate_text(
 pub async fn resize_main_window(app: AppHandle, height: f64) -> AppResult<()> {
     if let Some(w) = app.get_webview_window("main") {
         use tauri::LogicalSize;
-        let _ = w.set_size(LogicalSize::new(WIN_WIDTH, height));
+        // Preserve the user's current (possibly manually-resized) width and only
+        // adjust the height for the settings panel. Fall back to WIN_WIDTH if the
+        // current size can't be read.
+        let width = w
+            .inner_size()
+            .ok()
+            .and_then(|physical| w.scale_factor().ok().map(|s| physical.width as f64 / s))
+            .filter(|w| *w > 0.0)
+            .unwrap_or(WIN_WIDTH);
+        let _ = w.set_size(LogicalSize::new(width, height));
     }
     Ok(())
 }

--- a/src-tauri/src/llm_translate.rs
+++ b/src-tauri/src/llm_translate.rs
@@ -46,23 +46,30 @@ impl LlmTranslateClient {
         base_url: &str,
         api_key: &str,
         model: &str,
+        prompt: &str,
+        auto_prompt: &str,
     ) -> AppResult<TextTranslationResult> {
         let from_label = lang_label(from);
         let to_label = lang_label(to);
 
-        let system_prompt = if from == "auto" {
-            format!(
-                "You are a professional translator. Detect the source language and translate the following text to {}. \
-                 Only output the translation, nothing else. Do not add explanations or notes.",
-                to_label
-            )
+        // Pick the prompt template based on whether the source language is
+        // auto-detect. Each has its own user-configurable template, falling back
+        // to the built-in default when empty. `{from}` and `{to}` placeholders
+        // are substituted with the resolved language labels.
+        let template = if from == "auto" {
+            if auto_prompt.trim().is_empty() {
+                crate::models::default_llm_auto_prompt()
+            } else {
+                auto_prompt.to_string()
+            }
+        } else if prompt.trim().is_empty() {
+            crate::models::default_llm_prompt()
         } else {
-            format!(
-                "You are a professional translator. Translate the following text from {} to {}. \
-                 Only output the translation, nothing else. Do not add explanations or notes.",
-                from_label, to_label
-            )
+            prompt.to_string()
         };
+        let system_prompt = template
+            .replace("{from}", from_label)
+            .replace("{to}", to_label);
 
         let url = base_url.trim().to_string();
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -90,7 +90,9 @@ fn main() {
         }))
         .plugin(tauri_plugin_autostart::init(
             MacosLauncher::LaunchAgent,
-            None,
+            // Launch silently on boot: the autostart entry runs the app with this
+            // flag so the main window stays hidden (tray only) on OS startup.
+            Some(vec!["--minimized"]),
         ))
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .setup(|app| {
@@ -186,6 +188,23 @@ fn main() {
 
             // ── Intercept window close → hide to tray ────────────────────
             let main_window = app.get_webview_window("main").unwrap();
+
+            // Silent startup: when launched via OS autostart the app is run with
+            // `--minimized`, so keep the main window hidden (tray only). The window
+            // is created hidden (see tauri.conf.json), so a normal launch must
+            // explicitly show it here.
+            let silent_start = std::env::args().any(|arg| arg == "--minimized");
+            if silent_start {
+                let _ = main_window.hide();
+                #[cfg(target_os = "macos")]
+                let _ = app.set_dock_visibility(false);
+            } else {
+                #[cfg(target_os = "macos")]
+                let _ = app.set_dock_visibility(true);
+                let _ = main_window.show();
+                let _ = main_window.set_focus();
+            }
+
             let mw = main_window.clone();
             main_window.on_window_event(move |event| {
                 if let tauri::WindowEvent::CloseRequested { api, .. } = event {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,6 +3,7 @@
 mod api;
 mod app_state;
 mod bing_translate;
+mod builtin_translate;
 mod capture;
 mod capture_window;
 mod commands;
@@ -20,6 +21,7 @@ use std::path::PathBuf;
 use api::YoudaoClient;
 use app_state::SharedState;
 use bing_translate::BingTranslateClient;
+use builtin_translate::BuiltinTranslateClient;
 use llm_translate::LlmTranslateClient;
 use commands::{
     begin_capture, begin_copy_capture, cancel_capture, capture_debug_log, clear_history,
@@ -146,8 +148,9 @@ fn main() {
 
                 let api_client = YoudaoClient::new(general_http.clone());
                 let bing_client = BingTranslateClient::new(bing_http);
+                let builtin_client = BuiltinTranslateClient::new();
                 let llm_client = LlmTranslateClient::new(general_http);
-                let text_translator = TextTranslator::new(bing_client, llm_client);
+                let text_translator = TextTranslator::new(bing_client, builtin_client, llm_client);
                 app_handle.manage(SharedState::new(
                     config_store,
                     settings,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -47,6 +47,10 @@ pub struct LlmConfig {
     pub api_key: String,
     #[serde(default = "default_llm_model")]
     pub model: String,
+    #[serde(default = "default_llm_prompt")]
+    pub prompt: String,
+    #[serde(default = "default_llm_auto_prompt")]
+    pub auto_prompt: String,
 }
 
 fn default_llm_base_url() -> String {
@@ -57,12 +61,32 @@ fn default_llm_model() -> String {
     "gpt-4o-mini".to_string()
 }
 
+/// Default system prompt for the LLM translation engine when the source
+/// language is explicitly chosen. Supports the placeholders `{from}` and `{to}`,
+/// which are replaced with the source and target language labels at request time.
+pub fn default_llm_prompt() -> String {
+    "You are a professional translator. Translate the following text from {from} to {to}. \
+     Only output the translation, nothing else. Do not add explanations or notes."
+        .to_string()
+}
+
+/// Default system prompt used when the source language is set to auto-detect.
+/// Only supports the `{to}` placeholder (the source language is left to the
+/// model to detect).
+pub fn default_llm_auto_prompt() -> String {
+    "You are a professional translator. Detect the source language and translate the following text to {to}. \
+     Only output the translation, nothing else. Do not add explanations or notes."
+        .to_string()
+}
+
 impl Default for LlmConfig {
     fn default() -> Self {
         Self {
             base_url: default_llm_base_url(),
             api_key: String::new(),
             model: default_llm_model(),
+            prompt: default_llm_prompt(),
+            auto_prompt: default_llm_auto_prompt(),
         }
     }
 }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -6,12 +6,35 @@ use serde_json::Value;
 #[serde(rename_all = "lowercase")]
 pub enum TextTranslateEngine {
     Bing,
+    Google,
+    Microsoft,
+    Transmart,
+    Yandex,
+    Iciba,
     Llm,
 }
 
 impl Default for TextTranslateEngine {
     fn default() -> Self {
         Self::Bing
+    }
+}
+
+/// How outbound requests to the built-in translation engines should be proxied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ProxyMode {
+    /// No proxy — connect directly.
+    None,
+    /// Use the OS system proxy (Windows Internet Settings / proxy app).
+    System,
+    /// Use a user-supplied proxy URL (see `custom_proxy`).
+    Custom,
+}
+
+impl Default for ProxyMode {
+    fn default() -> Self {
+        Self::System
     }
 }
 
@@ -77,6 +100,10 @@ pub struct TranslatorSettings {
     pub llm_config: LlmConfig,
     #[serde(default)]
     pub popup_shortcut: Option<String>,
+    #[serde(default)]
+    pub proxy_mode: ProxyMode,
+    #[serde(default)]
+    pub custom_proxy: String,
 }
 
 impl Default for TranslatorSettings {
@@ -119,6 +146,8 @@ impl Default for TranslatorSettings {
             text_translate_engine: TextTranslateEngine::default(),
             llm_config: LlmConfig::default(),
             popup_shortcut: None,
+            proxy_mode: ProxyMode::default(),
+            custom_proxy: String::new(),
         }
     }
 }

--- a/src-tauri/src/translate_engine.rs
+++ b/src-tauri/src/translate_engine.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::bing_translate::BingTranslateClient;
+use crate::builtin_translate::BuiltinTranslateClient;
 use crate::error::AppResult;
 use crate::llm_translate::LlmTranslateClient;
 use crate::models::{LlmConfig, TextTranslateEngine, TextTranslationResult};
@@ -8,13 +9,19 @@ use crate::models::{LlmConfig, TextTranslateEngine, TextTranslationResult};
 #[derive(Clone)]
 pub struct TextTranslator {
     bing: Arc<BingTranslateClient>,
+    builtin: Arc<BuiltinTranslateClient>,
     llm: Arc<LlmTranslateClient>,
 }
 
 impl TextTranslator {
-    pub fn new(bing: BingTranslateClient, llm: LlmTranslateClient) -> Self {
+    pub fn new(
+        bing: BingTranslateClient,
+        builtin: BuiltinTranslateClient,
+        llm: LlmTranslateClient,
+    ) -> Self {
         Self {
             bing: Arc::new(bing),
+            builtin: Arc::new(builtin),
             llm: Arc::new(llm),
         }
     }
@@ -26,9 +33,15 @@ impl TextTranslator {
         to: &str,
         engine: TextTranslateEngine,
         llm_config: &LlmConfig,
+        proxy: Option<&str>,
     ) -> AppResult<TextTranslationResult> {
         match engine {
             TextTranslateEngine::Bing => self.bing.translate(text, from, to).await,
+            TextTranslateEngine::Google => self.builtin.google(text, from, to, proxy).await,
+            TextTranslateEngine::Microsoft => self.builtin.microsoft(text, from, to, proxy).await,
+            TextTranslateEngine::Transmart => self.builtin.transmart(text, from, to, proxy).await,
+            TextTranslateEngine::Yandex => self.builtin.yandex(text, from, to, proxy).await,
+            TextTranslateEngine::Iciba => self.builtin.iciba(text, from, to, proxy).await,
             TextTranslateEngine::Llm => {
                 self.llm
                     .translate(

--- a/src-tauri/src/translate_engine.rs
+++ b/src-tauri/src/translate_engine.rs
@@ -51,6 +51,8 @@ impl TextTranslator {
                         &llm_config.base_url,
                         &llm_config.api_key,
                         &llm_config.model,
+                        &llm_config.prompt,
+                        &llm_config.auto_prompt,
                     )
                     .await
             }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,6 +26,7 @@
         "minHeight": 400,
         "decorations": true,
         "shadow": true,
+        "backgroundColor": "#F3F4F6",
         "visible": false
       }
     ]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,7 +25,8 @@
         "minWidth": 520,
         "minHeight": 400,
         "decorations": true,
-        "shadow": true
+        "shadow": true,
+        "visible": false
       }
     ]
   },

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
         "title": "Glance",
         "width": 520,
         "height": 400,
-        "resizable": false,
+        "resizable": true,
         "center": true,
         "minWidth": 520,
         "minHeight": 400,

--- a/ui/app.js
+++ b/ui/app.js
@@ -44,12 +44,27 @@ function settingsHeight() {
 }
 
 let debounceTimer = null;
+// Monotonic id for translation requests. Each new request supersedes older
+// in-flight ones so their (stale) results are discarded, letting the user edit
+// and re-translate at any time — even mid-translation.
+let translateSeq = 0;
 
 function debouncedTranslate() {
   if (debounceTimer) clearTimeout(debounceTimer);
   debounceTimer = setTimeout(() => {
     const text = state.inputText.trim();
-    if (text && !state.textLoading) translateText();
+    if (text) {
+      translateText();
+    } else {
+      // Input cleared: cancel any in-flight result and reset the output.
+      translateSeq++;
+      state.textLoading = false;
+      state.translatedText = "";
+      state.alternatives = [];
+      state.detectedLang = "";
+      updateOutputArea();
+      updateDetectedLang();
+    }
   }, 500);
 }
 
@@ -465,7 +480,10 @@ async function startCapture() {
 
 async function translateText() {
   const text = state.inputText.trim();
-  if (!text || state.textLoading) return;
+  if (!text) return;
+
+  // Claim this as the latest request; older in-flight ones become stale.
+  const seq = ++translateSeq;
 
   state.textLoading = true;
   state.translatedText = "";
@@ -475,25 +493,32 @@ async function translateText() {
 
   // Validate LLM config
   if (state.settings.textTranslateEngine === "llm" && !state.settings.llmConfig.apiKey) {
-    state.textLoading = false;
-    state.status = "请先在设置中配置 API Key";
-    state.statusType = "error";
-    updateOutputArea();
+    if (seq === translateSeq) {
+      state.textLoading = false;
+      state.status = "请先在设置中配置 API Key";
+      state.statusType = "error";
+      updateOutputArea();
+    }
     return;
   }
 
   try {
     const r = await invoke("translate_text", { text, fromLang: state.settings.fromLang, toLang: state.settings.toLang });
+    if (seq !== translateSeq) return; // superseded by a newer request
     state.translatedText = r.translatedText;
     state.alternatives = r.alternatives || [];
     state.detectedLang = r.fromLangDetected;
     updateDetectedLang();
   } catch (err) {
+    if (seq !== translateSeq) return; // superseded; ignore stale error
     state.status = String(err);
     state.statusType = "error";
   } finally {
-    state.textLoading = false;
-    updateOutputArea();
+    // Only the latest request controls the loading state / final render.
+    if (seq === translateSeq) {
+      state.textLoading = false;
+      updateOutputArea();
+    }
   }
 }
 

--- a/ui/app.js
+++ b/ui/app.js
@@ -161,7 +161,9 @@ function defaultSettings() {
     llmConfig: {
       baseUrl: "https://api.openai.com/v1/chat/completions",
       apiKey: "",
-      model: "gpt-4o-mini"
+      model: "gpt-4o-mini",
+      prompt: "You are a professional translator. Translate the following text from {from} to {to}. Only output the translation, nothing else. Do not add explanations or notes.",
+      autoPrompt: "You are a professional translator. Detect the source language and translate the following text to {to}. Only output the translation, nothing else. Do not add explanations or notes."
     },
     popupShortcut: null,
     proxyMode: "system",
@@ -362,6 +364,20 @@ function renderMain() {
                     value="${escapeHtml(state.settings.llmConfig.model)}"
                     placeholder="gpt-4o-mini" />
           </div>
+          <div class="settings-row settings-row-vertical">
+            <span class="settings-label">提示词（指定源语言）
+              <span class="settings-hint">可用 {from} / {to} 表示源/目标语言</span>
+            </span>
+            <textarea class="settings-input settings-textarea" id="llm-prompt" rows="4"
+                    placeholder="${escapeHtml(defaultSettings().llmConfig.prompt)}">${escapeHtml(state.settings.llmConfig.prompt || "")}</textarea>
+          </div>
+          <div class="settings-row settings-row-vertical">
+            <span class="settings-label">提示词（自动检测源语言）
+              <span class="settings-hint">源语言为“自动检测”时使用，可用 {to}</span>
+            </span>
+            <textarea class="settings-input settings-textarea" id="llm-auto-prompt" rows="4"
+                    placeholder="${escapeHtml(defaultSettings().llmConfig.autoPrompt)}">${escapeHtml(state.settings.llmConfig.autoPrompt || "")}</textarea>
+          </div>
         </div>
       </div>
     </div>`;
@@ -454,9 +470,13 @@ function renderMain() {
   const baseUrlInput = document.querySelector("#llm-base-url");
   const apiKeyInput = document.querySelector("#llm-api-key");
   const modelInput = document.querySelector("#llm-model");
+  const promptInput = document.querySelector("#llm-prompt");
+  const autoPromptInput = document.querySelector("#llm-auto-prompt");
   if (baseUrlInput) baseUrlInput.addEventListener("change", e => { state.settings.llmConfig.baseUrl = e.target.value.trim(); saveSettings().catch(() => {}); });
   if (apiKeyInput) apiKeyInput.addEventListener("change", e => { state.settings.llmConfig.apiKey = e.target.value.trim(); saveSettings().catch(() => {}); });
   if (modelInput) modelInput.addEventListener("change", e => { state.settings.llmConfig.model = e.target.value.trim(); saveSettings().catch(() => {}); });
+  if (promptInput) promptInput.addEventListener("change", e => { state.settings.llmConfig.prompt = e.target.value; saveSettings().catch(() => {}); });
+  if (autoPromptInput) autoPromptInput.addEventListener("change", e => { state.settings.llmConfig.autoPrompt = e.target.value; saveSettings().catch(() => {}); });
 
   inp.focus();
 }

--- a/ui/app.js
+++ b/ui/app.js
@@ -36,7 +36,50 @@ const PROXY_MODES = [
   { value: "none", label: "不使用" }
 ];
 
+// Measure the height the window needs to fit the whole app content (header +
+// translation area + settings panel) without leaving blank space.
+//
+// IMPORTANT: the settings panel uses `flex: 1 1 auto`, so once the window has
+// been enlarged the panel is stretched to fill the remaining space and its
+// `offsetHeight`/`scrollHeight` no longer reflect the content's natural height.
+// Reading those would make the window grow a little on every engine switch.
+// Instead we measure the panel's *content* (its `.settings-section` children),
+// which is unaffected by how tall the panel is stretched.
 function settingsHeight() {
+  const appEl = document.querySelector(".bento-app");
+  const header = document.querySelector(".header-block");
+  const textBlock = document.querySelector(".text-block");
+  const panel = document.querySelector("#settings-panel");
+  if (appEl && header && textBlock && panel) {
+    const appCs = getComputedStyle(appEl);
+    const appPadding = parseFloat(appCs.paddingTop) + parseFloat(appCs.paddingBottom);
+    const appGap = parseFloat(appCs.rowGap || appCs.gap) || 0;
+
+    // Natural content height of the settings panel = its own vertical padding
+    // plus the height of every visible section inside it.
+    const panelCs = getComputedStyle(panel);
+    let panelContent = parseFloat(panelCs.paddingTop) + parseFloat(panelCs.paddingBottom);
+    panel.querySelectorAll(":scope > .settings-section").forEach(section => {
+      if (getComputedStyle(section).display === "none") return;
+      const sCs = getComputedStyle(section);
+      panelContent +=
+        section.offsetHeight +
+        parseFloat(sCs.marginTop) +
+        parseFloat(sCs.marginBottom);
+    });
+
+    // header + text-block + panel content, with two gaps between the three
+    // top-level blocks, plus the app container padding.
+    const total =
+      header.offsetHeight +
+      textBlock.offsetHeight +
+      panelContent +
+      appGap * 2 +
+      appPadding;
+    const measured = Math.ceil(total) + 2;
+    if (measured > 0) return measured;
+  }
+  // Fallback estimate.
   let h = 560;
   if (state.settings?.textTranslateEngine === "llm") h += 200;
   if (state.settings?.proxyMode === "custom") h += 56;
@@ -219,7 +262,7 @@ function renderMain() {
   }
 
   app.innerHTML = `
-    <div class="bento-app">
+    <div class="bento-app${state.settingsOpen ? " settings-open" : ""}">
       <div class="block header-block" data-tauri-drag-region>
         <div class="header-left">
           <div class="app-title">Glance</div>
@@ -347,6 +390,7 @@ function renderMain() {
     const panel = document.querySelector("#settings-panel");
     const btn = e.currentTarget;
     panel.style.display = state.settingsOpen ? "" : "none";
+    document.querySelector(".bento-app")?.classList.toggle("settings-open", state.settingsOpen);
     btn.classList.toggle("open", state.settingsOpen);
     if (state.settingsOpen) {
       invoke?.("resize_main_window", { height: settingsHeight() }).catch(() => {});
@@ -380,8 +424,11 @@ function renderMain() {
       // Toggle LLM settings visibility
       const llmSettings = document.querySelector("#llm-settings");
       if (llmSettings) llmSettings.style.display = newEngine === "llm" ? "" : "none";
-      // Resize window
-      invoke?.("resize_main_window", { height: settingsHeight() }).catch(() => {});
+      // Resize window only while the settings panel is open; otherwise keep the
+      // compact translation view unchanged.
+      if (state.settingsOpen) {
+        invoke?.("resize_main_window", { height: settingsHeight() }).catch(() => {});
+      }
     });
   });
 
@@ -395,7 +442,9 @@ function renderMain() {
       document.querySelectorAll("#proxy-switcher .engine-btn").forEach(b => b.classList.toggle("active", b.dataset.proxy === newMode));
       const customRow = document.querySelector("#custom-proxy-row");
       if (customRow) customRow.style.display = newMode === "custom" ? "" : "none";
-      invoke?.("resize_main_window", { height: settingsHeight() }).catch(() => {});
+      if (state.settingsOpen) {
+        invoke?.("resize_main_window", { height: settingsHeight() }).catch(() => {});
+      }
     });
   });
   const customProxyInput = document.querySelector("#custom-proxy");

--- a/ui/app.js
+++ b/ui/app.js
@@ -22,8 +22,26 @@ const TTS_LANG_MAP = {
 
 const TRANSLATE_ENGINES = [
   { value: "bing", label: "必应" },
+  { value: "google", label: "Google" },
+  { value: "microsoft", label: "微软" },
+  { value: "transmart", label: "腾讯" },
+  { value: "yandex", label: "Yandex" },
+  { value: "iciba", label: "词霸" },
   { value: "llm", label: "AI 大模型" }
 ];
+
+const PROXY_MODES = [
+  { value: "system", label: "系统代理" },
+  { value: "custom", label: "自定义" },
+  { value: "none", label: "不使用" }
+];
+
+function settingsHeight() {
+  let h = 560;
+  if (state.settings?.textTranslateEngine === "llm") h += 200;
+  if (state.settings?.proxyMode === "custom") h += 56;
+  return h;
+}
 
 let debounceTimer = null;
 
@@ -87,7 +105,9 @@ function defaultSettings() {
       apiKey: "",
       model: "gpt-4o-mini"
     },
-    popupShortcut: null
+    popupShortcut: null,
+    proxyMode: "system",
+    customProxy: ""
   };
 }
 
@@ -229,6 +249,20 @@ function renderMain() {
             </div>
           </div>
           <div class="settings-row">
+            <span class="settings-label">网络代理</span>
+            <div class="engine-switcher" id="proxy-switcher">
+              ${PROXY_MODES.map(p =>
+                `<button class="engine-btn ${state.settings.proxyMode === p.value ? "active" : ""}" data-proxy="${p.value}">${p.label}</button>`
+              ).join("")}
+            </div>
+          </div>
+          <div class="settings-row" id="custom-proxy-row" style="${state.settings.proxyMode === "custom" ? "" : "display:none"}">
+            <span class="settings-label">代理地址</span>
+            <input class="settings-input" id="custom-proxy" type="text"
+                    value="${escapeHtml(state.settings.customProxy || "")}"
+                    placeholder="http://127.0.0.1:7890" />
+          </div>
+          <div class="settings-row">
             <span class="settings-label">开机自启</span>
             <button class="toggle ${state.settings.autostart ? "on" : ""}" id="autostart" aria-pressed="${state.settings.autostart}"></button>
           </div>
@@ -300,8 +334,7 @@ function renderMain() {
     panel.style.display = state.settingsOpen ? "" : "none";
     btn.classList.toggle("open", state.settingsOpen);
     if (state.settingsOpen) {
-      const h = state.settings.textTranslateEngine === "llm" ? 620 : 520;
-      invoke?.("resize_main_window", { height: h }).catch(() => {});
+      invoke?.("resize_main_window", { height: settingsHeight() }).catch(() => {});
     } else {
       invoke?.("resize_main_window", { height: 400 }).catch(() => {});
     }
@@ -321,22 +354,37 @@ function renderMain() {
   document.querySelector("#popup-shortcut-row").addEventListener("click", e => { e.stopPropagation(); startPopupShortcutRecording(); });
 
   // Engine switcher
-  document.querySelectorAll(".engine-btn").forEach(btn => {
+  document.querySelectorAll("#engine-switcher .engine-btn").forEach(btn => {
     btn.addEventListener("click", e => {
       e.stopPropagation();
       const newEngine = e.currentTarget.dataset.engine;
       state.settings.textTranslateEngine = newEngine;
       saveSettings().catch(() => {});
       // Update active state
-      document.querySelectorAll(".engine-btn").forEach(b => b.classList.toggle("active", b.dataset.engine === newEngine));
+      document.querySelectorAll("#engine-switcher .engine-btn").forEach(b => b.classList.toggle("active", b.dataset.engine === newEngine));
       // Toggle LLM settings visibility
       const llmSettings = document.querySelector("#llm-settings");
       if (llmSettings) llmSettings.style.display = newEngine === "llm" ? "" : "none";
       // Resize window
-      const h = newEngine === "llm" ? 620 : 520;
-      invoke?.("resize_main_window", { height: h }).catch(() => {});
+      invoke?.("resize_main_window", { height: settingsHeight() }).catch(() => {});
     });
   });
+
+  // Proxy mode switcher
+  document.querySelectorAll("#proxy-switcher .engine-btn").forEach(btn => {
+    btn.addEventListener("click", e => {
+      e.stopPropagation();
+      const newMode = e.currentTarget.dataset.proxy;
+      state.settings.proxyMode = newMode;
+      saveSettings().catch(() => {});
+      document.querySelectorAll("#proxy-switcher .engine-btn").forEach(b => b.classList.toggle("active", b.dataset.proxy === newMode));
+      const customRow = document.querySelector("#custom-proxy-row");
+      if (customRow) customRow.style.display = newMode === "custom" ? "" : "none";
+      invoke?.("resize_main_window", { height: settingsHeight() }).catch(() => {});
+    });
+  });
+  const customProxyInput = document.querySelector("#custom-proxy");
+  if (customProxyInput) customProxyInput.addEventListener("change", e => { state.settings.customProxy = e.target.value.trim(); saveSettings().catch(() => {}); });
 
   // LLM config inputs
   const baseUrlInput = document.querySelector("#llm-base-url");

--- a/ui/capture.js
+++ b/ui/capture.js
@@ -14,6 +14,7 @@ const state = {
   copyTextMode: false,
   previewReady: false,
   resultImageBase64: "",
+  showResult: true,
   error: ""
 };
 
@@ -163,10 +164,15 @@ function updateSelectionLayer() {
 
   spinnerEl.hidden = !state.loading;
   if (state.resultImageBase64) {
-    resultEl.src = `data:image/jpeg;base64,${state.resultImageBase64}`;
-    resultEl.hidden = false;
-    previewEl.hidden = true;
-    hintEl.textContent = "Esc/右键关闭截图模式，或重新拖拽选择新区域";
+    if (state.showResult) {
+      resultEl.src = `data:image/jpeg;base64,${state.resultImageBase64}`;
+      resultEl.hidden = false;
+      previewEl.hidden = true;
+    } else {
+      resultEl.hidden = true;
+      previewEl.hidden = false;
+    }
+    hintEl.textContent = "区域内右键切换原文/译文 · Esc或区域外右键关闭";
   } else {
     resultEl.hidden = true;
     previewEl.hidden = false;
@@ -190,6 +196,13 @@ function pointFromEvent(event) {
   };
 }
 
+function pointerWithinSelection(event) {
+  if (!state.selectionCss) return false;
+  const p = pointFromEvent(event);
+  const r = state.selectionCss;
+  return p.x >= r.x && p.x <= r.x + r.width && p.y >= r.y && p.y <= r.y + r.height;
+}
+
 async function submitSelection(rectCss) {
   const rect = cssRectToImageRect(rectCss);
   if (rect.width <= 4 || rect.height <= 4) {
@@ -211,6 +224,7 @@ async function submitSelection(rectCss) {
     state.selectionImage = result.selection;
     state.selectionCss = imageRectToCssRect(result.selection);
     state.resultImageBase64 = result.imageBase64;
+    state.showResult = true;
   } catch (err) {
     setError(err);
   } finally {
@@ -225,6 +239,14 @@ function bindCaptureEvents() {
 
   root.addEventListener("contextmenu", (event) => {
     event.preventDefault();
+    // When a translation result is shown and the right-click lands inside the
+    // selected region, toggle between translation and original text instead of
+    // cancelling. Right-click outside the region (or with no result) cancels.
+    if (state.resultImageBase64 && pointerWithinSelection(event)) {
+      state.showResult = !state.showResult;
+      updateSelectionLayer();
+      return;
+    }
     cancelCapture();
   });
 
@@ -249,6 +271,11 @@ function bindCaptureEvents() {
 
   root.addEventListener("mouseup", async (event) => {
     if (event.button === 2) {
+      // Right-click is handled by the contextmenu listener (toggle inside the
+      // result region, cancel otherwise); avoid cancelling here as well.
+      if (state.resultImageBase64 && pointerWithinSelection(event)) {
+        return;
+      }
       await cancelCapture();
       return;
     }

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -420,10 +420,17 @@ body.capture-preparing *::after {
   padding: 4px 8px;
   font-size: 12px;
   color: var(--text-main);
-  width: 180px;
+  flex: 1 1 auto;
+  min-width: 0;
+  margin-left: 12px;
   text-align: right;
   outline: none;
   transition: border-color 0.15s;
+}
+/* Keep labels from being squeezed so the input can grow to fill the row. */
+.settings-row > .settings-label {
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 .settings-input:focus {
   border-color: var(--accent);
@@ -451,6 +458,7 @@ body.capture-preparing *::after {
 }
 .settings-textarea {
   width: 100%;
+  margin-left: 0;
   text-align: left;
   resize: vertical;
   min-height: 64px;

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -164,7 +164,18 @@ body.capture-preparing *::after {
   border-radius: var(--radius-xl);
   padding: 14px 16px;
   box-shadow: 0 2px 8px rgba(0,0,0,0.02);
-  flex-shrink: 0;
+  flex: 1 1 auto;
+  min-height: 0;
+  /* Scroll with the wheel when content overflows, but never show a scrollbar
+     (its appearance/disappearance during the resize caused a flash). */
+  overflow-y: auto;
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* old Edge */
+}
+.settings-panel::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+  display: none; /* Chromium / WebView2 */
 }
 .settings-section {
   display: flex;
@@ -196,6 +207,10 @@ body.capture-preparing *::after {
 .settings-btn.open { color: var(--accent); }
 
 /* ── Text block: left input + right output ── */
+/* The translation area fills the window when settings are collapsed. When the
+   settings panel is visible (window grows), its height is capped so it stays
+   the same size and the extra vertical space is absorbed by the settings
+   panel below. */
 .text-block {
   display: flex;
   flex-direction: row;
@@ -203,6 +218,10 @@ body.capture-preparing *::after {
   flex: 1 1 0;
   min-height: 0;
   overflow: hidden;
+}
+.bento-app.settings-open .text-block {
+  flex: 0 0 auto;
+  height: 200px;
 }
 .text-col {
   flex: 1 1 0;

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -432,6 +432,32 @@ body.capture-preparing *::after {
   color: #D4D4D8;
 }
 
+/* Prompt row: label on top, full-width textarea below. */
+.settings-row-vertical {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+}
+.settings-row-vertical .settings-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+.settings-hint {
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--text-sub);
+}
+.settings-textarea {
+  width: 100%;
+  text-align: left;
+  resize: vertical;
+  min-height: 64px;
+  line-height: 1.5;
+  font-family: inherit;
+}
+
 #llm-settings {
   margin-top: 8px;
 }


### PR DESCRIPTION
翻译完成后，在选区内右键可在译文和原文之间切换显示，方便对照阅读；选区外右键或 Esc 仍关闭截图。

- capture_window.rs (Windows/Linux 原生窗口):
  - ResultOverlay 新增 visible 标志，切换时重绘译文覆盖层或原始截图区域
  - 选区蓝色描边在译文/原文两种状态下都保留
  - 右键改在 Released 时处理，避免窗口在 Pressed 关闭后按键抬起穿透到下层窗口触发其原生右键菜单
- capture.js (macOS webview): 同步实现区域内右键切换 showResult