### PR TITLE
feat: bidirectional translation, cache, history and LLM hardening

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ tauri-plugin-single-instance = "2"
 thiserror = "2.0.11"
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread", "sync", "time"] }
 tracing = "0.1.41"
+tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt"] }
 uuid = { version = "1.12.1", features = ["serde", "v4"] }
 
@@ -38,6 +39,10 @@ objc2-app-kit = { version = "0.2.2", features = ["NSWindow", "NSEvent"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.55"
+windows-sys = { version = "0.59", features = [
+  "Win32_Foundation",
+  "Win32_Security_Cryptography",
+] }
 
 [features]
 default = []

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -44,18 +44,14 @@ impl SharedState {
         settings: TranslatorSettings,
         api_client: YoudaoClient,
         text_translator: TextTranslator,
+        translate_cache: TranslateCache,
     ) -> Self {
-        let translate_cache = Arc::new(TranslateCache::new(config_store.translate_cache_path()));
-        let cache = translate_cache.clone();
-        tauri::async_runtime::spawn(async move {
-            cache.load().await;
-        });
         Self {
             config_store: Arc::new(config_store),
             settings: Arc::new(RwLock::new(settings)),
             api_client: Arc::new(api_client),
             text_translator: Arc::new(text_translator),
-            translate_cache,
+            translate_cache: Arc::new(translate_cache),
             capture_in_progress: Arc::new(RwLock::new(false)),
             capture_session: Arc::new(RwLock::new(None)),
             capture_mode: Arc::new(RwLock::new(CaptureMode::default())),

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -5,6 +5,7 @@ use tokio::sync::RwLock;
 use crate::api::YoudaoClient;
 use crate::config::ConfigStore;
 use crate::models::{CaptureMode, OverlayPayload, TranslatorSettings};
+use crate::translate_cache::TranslateCache;
 use crate::translate_engine::TextTranslator;
 
 #[derive(Clone)]
@@ -30,6 +31,7 @@ pub struct SharedState {
     pub settings: Arc<RwLock<TranslatorSettings>>,
     pub api_client: Arc<YoudaoClient>,
     pub text_translator: Arc<TextTranslator>,
+    pub translate_cache: Arc<TranslateCache>,
     pub capture_in_progress: Arc<RwLock<bool>>,
     pub capture_session: Arc<RwLock<Option<ActiveCaptureSession>>>,
     pub capture_mode: Arc<RwLock<CaptureMode>>,
@@ -43,11 +45,17 @@ impl SharedState {
         api_client: YoudaoClient,
         text_translator: TextTranslator,
     ) -> Self {
+        let translate_cache = Arc::new(TranslateCache::new(config_store.translate_cache_path()));
+        let cache = translate_cache.clone();
+        tauri::async_runtime::spawn(async move {
+            cache.load().await;
+        });
         Self {
             config_store: Arc::new(config_store),
             settings: Arc::new(RwLock::new(settings)),
             api_client: Arc::new(api_client),
             text_translator: Arc::new(text_translator),
+            translate_cache,
             capture_in_progress: Arc::new(RwLock::new(false)),
             capture_session: Arc::new(RwLock::new(None)),
             capture_mode: Arc::new(RwLock::new(CaptureMode::default())),

--- a/src-tauri/src/builtin_translate.rs
+++ b/src-tauri/src/builtin_translate.rs
@@ -79,7 +79,9 @@ impl BuiltinTranslateClient {
             }
         }
 
-        let mut builder = Client::builder();
+        let mut builder = Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(5))
+            .timeout(std::time::Duration::from_secs(10));
         match proxy {
             Some(url) if !url.is_empty() => {
                 if let Ok(p) = reqwest::Proxy::all(url) {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -16,7 +16,7 @@ use crate::capture_window::{self, CaptureCommand, CaptureEvent};
 use crate::error::{AppError, AppResult};
 use crate::models::{
     CaptureMode, CaptureRect, CaptureTranslatePayload, CaptureViewPayload, HistoryQuery,
-    OcrTextResult, OverlayPayload, SelectionPayload, TextTranslationResult,
+    OcrTextResult, OverlayPayload, SelectionPayload, TextHistoryItem, TextTranslationResult,
     TranslationHistoryItem, TranslatorSettings,
 };
 use crate::popup_shortcut::{decide_popup_shortcut_action, PopupShortcutAction};
@@ -191,7 +191,7 @@ pub async fn translate_text(
     from_lang: String,
     to_lang: String,
 ) -> AppResult<TextTranslationResult> {
-    let (engine, llm_config, proxy_url) = {
+    let (engine, llm_config, proxy_url, cache_size) = {
         let settings = state.settings.read().await;
         let proxy_url = match settings.proxy_mode {
             crate::models::ProxyMode::None => None,
@@ -204,9 +204,38 @@ pub async fn translate_text(
             settings.text_translate_engine,
             settings.llm_config.clone(),
             proxy_url,
+            settings.cache_size,
         )
     };
+
+    // Persisted exact-match cache: repeat queries (e.g. re-pasting the same
+    // sentence, undo/redo editing) resolve instantly without another API call.
+    let model = if engine == crate::models::TextTranslateEngine::Llm {
+        llm_config.model.clone()
+    } else {
+        String::new()
+    };
     state
+        .translate_cache
+        .set_max_entries(cache_size)
+        .await;
+    let engine_key = serde_json::to_string(&engine).unwrap_or_default();
+    if let Some(hit) = state
+        .translate_cache
+        .get(&text, &from_lang, &to_lang, &engine_key, &model)
+        .await
+    {
+        tracing::info!(
+            "translate cache hit: engine={engine:?} from={from_lang} to={to_lang}"
+        );
+        return Ok(hit);
+    }
+    tracing::info!(
+        "translate request: engine={engine:?} from={from_lang} to={to_lang} chars={}",
+        text.chars().count()
+    );
+
+    let result = state
         .text_translator
         .translate(
             &text,
@@ -216,7 +245,84 @@ pub async fn translate_text(
             &llm_config,
             proxy_url.as_deref(),
         )
-        .await
+        .await?;
+
+    // Cache the result and record it in the text history (bounded by the
+    // configured limit). Both writes are fire-and-forget so they never block
+    // the response.
+    let cache = state.translate_cache.clone();
+    let cache_text = text.clone();
+    let cache_from = from_lang.clone();
+    let cache_to = to_lang.clone();
+    let cache_engine = engine_key;
+    let cache_model = model;
+    let cache_result = result.clone();
+    tauri::async_runtime::spawn(async move {
+        cache
+            .insert(
+                &cache_text,
+                &cache_from,
+                &cache_to,
+                &cache_engine,
+                &cache_model,
+                cache_result,
+            )
+            .await;
+        cache.save().await;
+    });
+
+    let store = state.config_store.clone();
+    let (history_limit, history_from, history_to, history_engine) = {
+        let settings = state.settings.read().await;
+        (
+            settings.history_limit,
+            settings.from_lang.clone(),
+            settings.to_lang.clone(),
+            serde_json::to_string(&engine).unwrap_or_default(),
+        )
+    };
+    let history_text = text.clone();
+    let history_result = result.clone();
+    tauri::async_runtime::spawn(async move {
+        let mut history = store.load_text_history().await.unwrap_or_default();
+        history.push(TextHistoryItem {
+            id: uuid::Uuid::new_v4().to_string(),
+            created_at: chrono::Utc::now(),
+            from_lang: history_from,
+            to_lang: history_to,
+            engine: history_engine,
+            source: history_text,
+            translated: history_result.translated_text,
+        });
+        if history.len() > history_limit {
+            history.truncate(history_limit);
+        }
+        if let Err(err) = store.save_text_history(&history).await {
+            tracing::warn!("text history save failed: {err}");
+        }
+    });
+
+    Ok(result)
+}
+
+#[tauri::command]
+pub async fn clear_text_history(state: State<'_, SharedState>) -> AppResult<()> {
+    state.config_store.save_text_history(&[]).await
+}
+
+#[tauri::command]
+pub async fn list_text_history(state: State<'_, SharedState>) -> AppResult<Vec<TextHistoryItem>> {
+    let mut items = state.config_store.load_text_history().await?;
+    items.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    Ok(items)
+}
+
+#[tauri::command]
+pub async fn clear_translate_cache(state: State<'_, SharedState>) -> AppResult<usize> {
+    let count = state.translate_cache.entry_count().await;
+    state.translate_cache.clear().await;
+    state.translate_cache.save().await;
+    Ok(count)
 }
 
 // ── Window ──────────────────────────────────────────────────────────────────
@@ -949,8 +1055,10 @@ async fn translate_capture_png(
             png_bytes,
             "capture.png".into(),
             "image/png".into(),
-            settings.from_lang.clone(),
-            settings.to_lang.clone(),
+            // 截图内容语言未知，源语言固定交给服务端自动检测，避免与
+            // 文本翻译的 fromLang 设置冲突（如设置 zh-CHS 却截英文图）。
+            "auto".to_string(),
+            settings.capture_to_lang.clone(),
             SelectionPayload {
                 x: 0.0,
                 y: 0.0,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -16,8 +16,8 @@ use crate::capture_window::{self, CaptureCommand, CaptureEvent};
 use crate::error::{AppError, AppResult};
 use crate::models::{
     CaptureMode, CaptureRect, CaptureTranslatePayload, CaptureViewPayload, HistoryQuery,
-    OcrTextResult, OverlayPayload, SelectionPayload, TextHistoryItem, TextTranslationResult,
-    TranslationHistoryItem, TranslatorSettings,
+    OcrTextResult, OverlayPayload, SelectionPayload, TextHistoryItem, TextSourceSide,
+    TextTranslationResult, TranslationHistoryItem, TranslatorSettings,
 };
 use crate::popup_shortcut::{decide_popup_shortcut_action, PopupShortcutAction};
 
@@ -190,8 +190,9 @@ pub async fn translate_text(
     text: String,
     from_lang: String,
     to_lang: String,
+    source_side: TextSourceSide,
 ) -> AppResult<TextTranslationResult> {
-    let (engine, llm_config, proxy_url, cache_size) = {
+    let (engine, llm_config, proxy_url, cache_size, history_limit) = {
         let settings = state.settings.read().await;
         let proxy_url = match settings.proxy_mode {
             crate::models::ProxyMode::None => None,
@@ -205,29 +206,31 @@ pub async fn translate_text(
             settings.llm_config.clone(),
             proxy_url,
             settings.cache_size,
+            settings.history_limit,
         )
     };
 
     // Persisted exact-match cache: repeat queries (e.g. re-pasting the same
     // sentence, undo/redo editing) resolve instantly without another API call.
-    let model = if engine == crate::models::TextTranslateEngine::Llm {
-        llm_config.model.clone()
-    } else {
-        String::new()
-    };
-    state
-        .translate_cache
-        .set_max_entries(cache_size)
-        .await;
+    state.translate_cache.set_max_entries(cache_size).await;
     let engine_key = serde_json::to_string(&engine).unwrap_or_default();
+    let cache_variant = crate::translate_cache::configuration_variant(engine, &llm_config);
     if let Some(hit) = state
         .translate_cache
-        .get(&text, &from_lang, &to_lang, &engine_key, &model)
+        .get(&text, &from_lang, &to_lang, &engine_key, &cache_variant)
         .await
     {
-        tracing::info!(
-            "translate cache hit: engine={engine:?} from={from_lang} to={to_lang}"
-        );
+        tracing::info!("translate cache hit: engine={engine:?} from={from_lang} to={to_lang}");
+        state.translate_cache.save().await;
+        let history_item =
+            make_text_history_item(text, from_lang, to_lang, engine, hit.clone(), source_side);
+        if let Err(err) = state
+            .config_store
+            .append_text_history(history_item, history_limit)
+            .await
+        {
+            tracing::warn!("text history save failed: {err}");
+        }
         return Ok(hit);
     }
     tracing::info!(
@@ -235,7 +238,7 @@ pub async fn translate_text(
         text.chars().count()
     );
 
-    let result = state
+    let outcome = state
         .text_translator
         .translate(
             &text,
@@ -246,68 +249,68 @@ pub async fn translate_text(
             proxy_url.as_deref(),
         )
         .await?;
+    let result = outcome.result;
 
-    // Cache the result and record it in the text history (bounded by the
-    // configured limit). Both writes are fire-and-forget so they never block
-    // the response.
-    let cache = state.translate_cache.clone();
-    let cache_text = text.clone();
-    let cache_from = from_lang.clone();
-    let cache_to = to_lang.clone();
-    let cache_engine = engine_key;
-    let cache_model = model;
-    let cache_result = result.clone();
-    tauri::async_runtime::spawn(async move {
-        cache
+    // A fallback result must not be cached as if it came from the requested
+    // engine. Doing so would make a temporary LLM outage permanently bypass
+    // the LLM for the same input.
+    if outcome.engine == engine {
+        state
+            .translate_cache
             .insert(
-                &cache_text,
-                &cache_from,
-                &cache_to,
-                &cache_engine,
-                &cache_model,
-                cache_result,
+                &text,
+                &from_lang,
+                &to_lang,
+                &engine_key,
+                &cache_variant,
+                result.clone(),
             )
             .await;
-        cache.save().await;
-    });
+        state.translate_cache.save().await;
+    }
 
-    let store = state.config_store.clone();
-    let (history_limit, history_from, history_to, history_engine) = {
-        let settings = state.settings.read().await;
-        (
-            settings.history_limit,
-            settings.from_lang.clone(),
-            settings.to_lang.clone(),
-            serde_json::to_string(&engine).unwrap_or_default(),
-        )
-    };
-    let history_text = text.clone();
-    let history_result = result.clone();
-    tauri::async_runtime::spawn(async move {
-        let mut history = store.load_text_history().await.unwrap_or_default();
-        history.push(TextHistoryItem {
-            id: uuid::Uuid::new_v4().to_string(),
-            created_at: chrono::Utc::now(),
-            from_lang: history_from,
-            to_lang: history_to,
-            engine: history_engine,
-            source: history_text,
-            translated: history_result.translated_text,
-        });
-        if history.len() > history_limit {
-            history.truncate(history_limit);
-        }
-        if let Err(err) = store.save_text_history(&history).await {
-            tracing::warn!("text history save failed: {err}");
-        }
-    });
+    let history_item = make_text_history_item(
+        text,
+        from_lang,
+        to_lang,
+        outcome.engine,
+        result.clone(),
+        source_side,
+    );
+    if let Err(err) = state
+        .config_store
+        .append_text_history(history_item, history_limit)
+        .await
+    {
+        tracing::warn!("text history save failed: {err}");
+    }
 
     Ok(result)
 }
 
+fn make_text_history_item(
+    text: String,
+    from_lang: String,
+    to_lang: String,
+    engine: crate::models::TextTranslateEngine,
+    result: TextTranslationResult,
+    source_side: TextSourceSide,
+) -> TextHistoryItem {
+    TextHistoryItem {
+        id: uuid::Uuid::new_v4().to_string(),
+        created_at: chrono::Utc::now(),
+        from_lang,
+        to_lang,
+        engine: format!("{engine:?}").to_lowercase(),
+        source: text,
+        translated: result.translated_text,
+        source_side,
+    }
+}
+
 #[tauri::command]
 pub async fn clear_text_history(state: State<'_, SharedState>) -> AppResult<()> {
-    state.config_store.save_text_history(&[]).await
+    state.config_store.clear_text_history().await
 }
 
 #[tauri::command]

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,6 +1,8 @@
-﻿use std::path::PathBuf;
+use std::path::PathBuf;
+use std::sync::Arc;
 
 use tokio::fs;
+use tokio::sync::Mutex;
 
 use crate::error::AppResult;
 use crate::models::{TextHistoryItem, TranslationHistoryItem, TranslatorSettings};
@@ -12,6 +14,7 @@ pub struct ConfigStore {
     history_file: PathBuf,
     text_history_file: PathBuf,
     cache_file: PathBuf,
+    text_history_lock: Arc<Mutex<()>>,
 }
 
 impl ConfigStore {
@@ -26,6 +29,7 @@ impl ConfigStore {
             history_file,
             text_history_file,
             cache_file,
+            text_history_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -89,15 +93,111 @@ impl ConfigStore {
     }
 
     pub async fn load_text_history(&self) -> AppResult<Vec<TextHistoryItem>> {
+        let _guard = self.text_history_lock.lock().await;
+        self.load_text_history_unlocked().await
+    }
+
+    pub async fn append_text_history(&self, item: TextHistoryItem, limit: usize) -> AppResult<()> {
+        let _guard = self.text_history_lock.lock().await;
+        let mut history = self.load_text_history_unlocked().await?;
+        history.push(item);
+        let overflow = history.len().saturating_sub(limit);
+        if overflow > 0 {
+            history.drain(..overflow);
+        }
+        self.write_text_history_unlocked(&history).await
+    }
+
+    pub async fn clear_text_history(&self) -> AppResult<()> {
+        let _guard = self.text_history_lock.lock().await;
+        self.write_text_history_unlocked(&[]).await
+    }
+
+    async fn load_text_history_unlocked(&self) -> AppResult<Vec<TextHistoryItem>> {
         self.ensure().await?;
         let bytes = fs::read(&self.text_history_file).await?;
         Ok(serde_json::from_slice(&bytes)?)
     }
 
-    pub async fn save_text_history(&self, history: &[TextHistoryItem]) -> AppResult<()> {
+    async fn write_text_history_unlocked(&self, history: &[TextHistoryItem]) -> AppResult<()> {
         self.ensure().await?;
         let bytes = serde_json::to_vec_pretty(history)?;
         fs::write(&self.text_history_file, bytes).await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use chrono::Utc;
+
+    use super::*;
+    use crate::models::TextSourceSide;
+
+    fn history_item(source: impl Into<String>) -> TextHistoryItem {
+        let source = source.into();
+        TextHistoryItem {
+            id: source.clone(),
+            created_at: Utc::now(),
+            from_lang: "en".to_string(),
+            to_lang: "zh-CHS".to_string(),
+            engine: "bing".to_string(),
+            source,
+            translated: "译文".to_string(),
+            source_side: TextSourceSide::Left,
+        }
+    }
+
+    fn test_store(name: &str) -> ConfigStore {
+        let dir = std::env::temp_dir().join(format!("glance-{name}-{}", uuid::Uuid::new_v4()));
+        ConfigStore::new(dir)
+    }
+
+    #[tokio::test]
+    async fn text_history_limit_keeps_newest_entries() {
+        let store = test_store("history-limit");
+        store
+            .append_text_history(history_item("one"), 2)
+            .await
+            .unwrap();
+        store
+            .append_text_history(history_item("two"), 2)
+            .await
+            .unwrap();
+        store
+            .append_text_history(history_item("three"), 2)
+            .await
+            .unwrap();
+
+        let history = store.load_text_history().await.unwrap();
+        let sources: Vec<_> = history.iter().map(|item| item.source.as_str()).collect();
+        assert_eq!(sources, ["two", "three"]);
+        let _ = tokio::fs::remove_dir_all(&store.base_dir).await;
+    }
+
+    #[tokio::test]
+    async fn concurrent_text_history_appends_do_not_lose_entries() {
+        let store = Arc::new(test_store("history-concurrency"));
+        let mut tasks = Vec::new();
+        for index in 0..20 {
+            let store = store.clone();
+            tasks.push(tokio::spawn(async move {
+                store
+                    .append_text_history(history_item(index.to_string()), 100)
+                    .await
+                    .unwrap();
+            }));
+        }
+        for task in tasks {
+            task.await.unwrap();
+        }
+
+        let history = store.load_text_history().await.unwrap();
+        let ids: HashSet<_> = history.iter().map(|item| item.id.as_str()).collect();
+        assert_eq!(history.len(), 20);
+        assert_eq!(ids.len(), 20);
+        let _ = tokio::fs::remove_dir_all(&store.base_dir).await;
     }
 }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -3,24 +3,34 @@
 use tokio::fs;
 
 use crate::error::AppResult;
-use crate::models::{TranslationHistoryItem, TranslatorSettings};
+use crate::models::{TextHistoryItem, TranslationHistoryItem, TranslatorSettings};
 
 #[derive(Debug, Clone)]
 pub struct ConfigStore {
     base_dir: PathBuf,
     settings_file: PathBuf,
     history_file: PathBuf,
+    text_history_file: PathBuf,
+    cache_file: PathBuf,
 }
 
 impl ConfigStore {
     pub fn new(base_dir: PathBuf) -> Self {
         let settings_file = base_dir.join("settings.json");
         let history_file = base_dir.join("history.json");
+        let text_history_file = base_dir.join("text_history.json");
+        let cache_file = base_dir.join("translate_cache.json");
         Self {
             base_dir,
             settings_file,
             history_file,
+            text_history_file,
+            cache_file,
         }
+    }
+
+    pub fn translate_cache_path(&self) -> PathBuf {
+        self.cache_file.clone()
     }
 
     pub async fn ensure(&self) -> AppResult<()> {
@@ -32,18 +42,35 @@ impl ConfigStore {
         if fs::metadata(&self.history_file).await.is_err() {
             fs::write(&self.history_file, b"[]").await?;
         }
+        if fs::metadata(&self.text_history_file).await.is_err() {
+            fs::write(&self.text_history_file, b"[]").await?;
+        }
         Ok(())
     }
 
     pub async fn load_settings(&self) -> AppResult<TranslatorSettings> {
         self.ensure().await?;
         let bytes = fs::read(&self.settings_file).await?;
-        Ok(serde_json::from_slice(&bytes)?)
+        let mut settings: TranslatorSettings = serde_json::from_slice(&bytes)?;
+        // API key is stored encrypted on Windows; decrypt on load.
+        let stored_key = settings.llm_config.api_key.clone();
+        let legacy_plaintext = !stored_key.is_empty() && !stored_key.starts_with("enc:v1:");
+        settings.llm_config.api_key = crate::secure::decrypt(&stored_key);
+        // One-time migration: persist the legacy plaintext key encrypted.
+        if legacy_plaintext {
+            let _ = self.save_settings(&settings).await;
+        }
+        Ok(settings)
     }
 
     pub async fn save_settings(&self, settings: &TranslatorSettings) -> AppResult<()> {
         self.ensure().await?;
-        let bytes = serde_json::to_vec_pretty(settings)?;
+        let mut stored = settings.clone();
+        // Encrypt the API key at rest. `encrypt` falls back to plaintext when
+        // DPAPI is unavailable, and re-encrypting an already-encrypted value is
+        // a no-op (it is recognized by its prefix).
+        stored.llm_config.api_key = crate::secure::encrypt(&stored.llm_config.api_key);
+        let bytes = serde_json::to_vec_pretty(&stored)?;
         fs::write(&self.settings_file, bytes).await?;
         Ok(())
     }
@@ -58,6 +85,19 @@ impl ConfigStore {
         self.ensure().await?;
         let bytes = serde_json::to_vec_pretty(history)?;
         fs::write(&self.history_file, bytes).await?;
+        Ok(())
+    }
+
+    pub async fn load_text_history(&self) -> AppResult<Vec<TextHistoryItem>> {
+        self.ensure().await?;
+        let bytes = fs::read(&self.text_history_file).await?;
+        Ok(serde_json::from_slice(&bytes)?)
+    }
+
+    pub async fn save_text_history(&self, history: &[TextHistoryItem]) -> AppResult<()> {
+        self.ensure().await?;
+        let bytes = serde_json::to_vec_pretty(history)?;
+        fs::write(&self.text_history_file, bytes).await?;
         Ok(())
     }
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -11,6 +11,8 @@ pub enum AppError {
     Base64(#[from] base64::DecodeError),
     #[error("capture error: {0}")]
     Capture(String),
+    #[error("http error {0}: {1}")]
+    HttpStatus(u16, String),
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
     #[error("json error: {0}")]
@@ -25,6 +27,25 @@ pub enum AppError {
     Tauri(#[from] tauri::Error),
     #[error("image error: {0}")]
     Image(#[from] image::ImageError),
+    #[error("request timed out: {0}")]
+    Timeout(String),
+}
+
+impl AppError {
+    /// Whether retrying the same request has a reasonable chance of succeeding.
+    /// Used by the retry/fallback logic in the translation engine.
+    pub fn is_transient(&self) -> bool {
+        match self {
+            // Network failures include DNS, connect and request timeouts.
+            AppError::Network(e) => !e.is_connect() && !e.is_timeout() || e.is_timeout(),
+            AppError::Timeout(_) => true,
+            // 408 (timeout), 429 (rate limited), 5xx (server errors).
+            AppError::HttpStatus(code, _) => {
+                *code == 408 || *code == 429 || (500..600).contains(code)
+            }
+            _ => false,
+        }
+    }
 }
 
 impl From<AppError> for InvokeError {

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -37,7 +37,9 @@ impl AppError {
     pub fn is_transient(&self) -> bool {
         match self {
             // Network failures include DNS, connect and request timeouts.
-            AppError::Network(e) => !e.is_connect() && !e.is_timeout() || e.is_timeout(),
+            AppError::Network(e) => {
+                e.is_connect() || e.is_timeout() || e.is_request() || e.is_body()
+            }
             AppError::Timeout(_) => true,
             // 408 (timeout), 429 (rate limited), 5xx (server errors).
             AppError::HttpStatus(code, _) => {

--- a/src-tauri/src/llm_translate.rs
+++ b/src-tauri/src/llm_translate.rs
@@ -10,11 +10,15 @@ pub struct LlmTranslateClient {
     http: Arc<Client>,
 }
 
+const LLM_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
 #[derive(Serialize)]
 struct ChatRequest {
     model: String,
     messages: Vec<ChatMessage>,
     temperature: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -31,6 +35,8 @@ struct ChatResponse {
 #[derive(Deserialize)]
 struct ChatChoice {
     message: ChatMessage,
+    #[serde(default)]
+    finish_reason: Option<String>,
 }
 
 impl LlmTranslateClient {
@@ -48,6 +54,7 @@ impl LlmTranslateClient {
         model: &str,
         prompt: &str,
         auto_prompt: &str,
+        max_tokens: Option<u32>,
     ) -> AppResult<TextTranslationResult> {
         let from_label = lang_label(from);
         let to_label = lang_label(to);
@@ -73,6 +80,19 @@ impl LlmTranslateClient {
 
         let url = base_url.trim().to_string();
 
+        // A hard rule appended AFTER the user's custom prompt: the model must
+        // never chat, refuse, or echo instructions. Whatever the input
+        // language, it has to produce target-language text (or the input
+        // unchanged when it already is in the target language). This keeps
+        // mixed-language or wrong-side input from producing chatty replies.
+        let hard_rule = format!(
+            "Hard rule: the user text may be in any language, not necessarily {from_label}. \
+             Always output the translation in {to_label}. If the text is entirely in {to_label}, \
+             output it unchanged. If the text contains parts in other languages, translate those \
+             parts into {to_label} so the whole output is in {to_label}. Never explain, comment, \
+             ask questions, or refuse — output only the {to_label} text."
+        );
+
         let request = ChatRequest {
             model: model.to_string(),
             messages: vec![
@@ -81,22 +101,30 @@ impl LlmTranslateClient {
                     content: system_prompt,
                 },
                 ChatMessage {
+                    role: "system".to_string(),
+                    content: hard_rule,
+                },
+                ChatMessage {
                     role: "user".to_string(),
                     content: text.to_string(),
                 },
             ],
             temperature: 0.3,
+            max_tokens,
         };
 
-        let resp = self
-            .http
-            .post(&url)
-            .header("Authorization", format!("Bearer {}", api_key))
-            .header("Content-Type", "application/json")
-            .json(&request)
-            .send()
-            .await
-            .map_err(|e| AppError::Api(format!("LLM translate request failed: {e}")))?;
+        let resp = tokio::time::timeout(
+            LLM_REQUEST_TIMEOUT,
+            self.http
+                .post(&url)
+                .header("Authorization", format!("Bearer {}", api_key))
+                .header("Content-Type", "application/json")
+                .json(&request)
+                .send(),
+        )
+        .await
+        .map_err(|_| AppError::Timeout("LLM request timed out".into()))?
+        .map_err(|e| AppError::Network(e))?;
 
         let status = resp.status();
         let body_text = resp
@@ -106,20 +134,18 @@ impl LlmTranslateClient {
 
         if !status.is_success() {
             let detail = &body_text[..body_text.len().min(500)];
-            return Err(AppError::Api(format!(
-                "LLM API error (HTTP {}): {}",
+            return Err(AppError::HttpStatus(
                 status.as_u16(),
-                detail
-            )));
+                format!("LLM API error (HTTP {}): {}", status.as_u16(), detail),
+            ));
         }
 
         let chat_resp: ChatResponse = serde_json::from_str(&body_text)
             .map_err(|e| AppError::Api(format!("LLM translate parse failed: {e}")))?;
 
-        let translated = chat_resp
-            .choices
-            .first()
-            .and_then(|c| Some(c.message.content.clone()))
+        let choice = chat_resp.choices.first();
+        let translated = choice
+            .map(|c| c.message.content.clone())
             .unwrap_or_default()
             .trim()
             .to_string();
@@ -128,11 +154,72 @@ impl LlmTranslateClient {
             return Err(AppError::Api("LLM returned empty translation".into()));
         }
 
+        // Surface truncation so the user knows the result is incomplete.
+        let mut alternatives = Vec::new();
+        if choice.and_then(|c| c.finish_reason.as_deref()) == Some("length") {
+            alternatives.push("⚠ 输出达到 token 上限，可能被截断".to_string());
+        }
+        // Identity output: with the hard rule above this is only expected when
+        // the input was already in the target language — otherwise it usually
+        // means the source/target language pair is wrong for the text.
+        if translated == text.trim() {
+            alternatives.push("⚠ 结果与原文相同：可能原文已是目标语言，或方向设置有误".to_string());
+        }
+
+        // When the source is auto-detect, resolve the actual language with a
+        // lightweight local heuristic. This makes the detection tag / TTS
+        // language reliable without an extra API call.
+        let detected = if from == "auto" {
+            detect_lang(text)
+        } else {
+            from.to_string()
+        };
+
         Ok(TextTranslationResult {
             translated_text: translated,
-            from_lang_detected: from.to_string(),
-            alternatives: Vec::new(),
+            from_lang_detected: detected,
+            alternatives,
         })
+    }
+}
+
+/// Cheap local language guess for auto-detect mode, good enough to drive the
+/// detection tag and TTS voice selection. Falls back to "auto" when unclear.
+fn detect_lang(text: &str) -> String {
+    let mut han = 0usize;
+    let mut kana = 0usize;
+    let mut hangul = 0usize;
+    let mut latin = 0usize;
+    let mut total = 0usize;
+
+    for c in text.chars() {
+        total += 1;
+        match c {
+            'ぁ'..='ゖ' | 'ァ'..='ヺ' | 'ー' => kana += 1,
+            '\u{ac00}'..='\u{d7a3}' => hangul += 1,
+            '\u{4e00}'..='\u{9fff}' | '\u{3400}'..='\u{4dbf}' | '\u{f900}'..='\u{faff}' => han += 1,
+            'a'..='z' | 'A'..='Z' => latin += 1,
+            _ => {}
+        }
+    }
+    if total == 0 {
+        return "auto".to_string();
+    }
+
+    let han_ratio = han as f64 / total as f64;
+    let kana_ratio = kana as f64 / total as f64;
+    let hangul_ratio = hangul as f64 / total as f64;
+
+    if kana_ratio > 0.05 {
+        "ja".to_string()
+    } else if hangul_ratio > 0.1 {
+        "ko".to_string()
+    } else if han_ratio > 0.1 {
+        "zh-CHS".to_string()
+    } else if latin as f64 / total as f64 > 0.3 {
+        "en".to_string()
+    } else {
+        "auto".to_string()
     }
 }
 

--- a/src-tauri/src/llm_translate.rs
+++ b/src-tauri/src/llm_translate.rs
@@ -113,27 +113,25 @@ impl LlmTranslateClient {
             max_tokens,
         };
 
-        let resp = tokio::time::timeout(
-            LLM_REQUEST_TIMEOUT,
-            self.http
+        let (status, body_text) = tokio::time::timeout(LLM_REQUEST_TIMEOUT, async {
+            let resp = self
+                .http
                 .post(&url)
                 .header("Authorization", format!("Bearer {}", api_key))
                 .header("Content-Type", "application/json")
                 .json(&request)
-                .send(),
-        )
+                .send()
+                .await
+                .map_err(AppError::Network)?;
+            let status = resp.status();
+            let body_text = resp.text().await.map_err(AppError::Network)?;
+            Ok::<_, AppError>((status, body_text))
+        })
         .await
-        .map_err(|_| AppError::Timeout("LLM request timed out".into()))?
-        .map_err(|e| AppError::Network(e))?;
-
-        let status = resp.status();
-        let body_text = resp
-            .text()
-            .await
-            .map_err(|e| AppError::Api(format!("LLM translate read body failed: {e}")))?;
+        .map_err(|_| AppError::Timeout("LLM request timed out".into()))??;
 
         if !status.is_success() {
-            let detail = &body_text[..body_text.len().min(500)];
+            let detail = truncate_chars(&body_text, 500);
             return Err(AppError::HttpStatus(
                 status.as_u16(),
                 format!("LLM API error (HTTP {}): {}", status.as_u16(), detail),
@@ -181,6 +179,10 @@ impl LlmTranslateClient {
             alternatives,
         })
     }
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    value.chars().take(max_chars).collect()
 }
 
 /// Cheap local language guess for auto-detect mode, good enough to drive the
@@ -236,5 +238,18 @@ fn lang_label(code: &str) -> &str {
         "ru" => "Russian",
         "es" => "Spanish",
         _ => code,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_detail_truncation_preserves_utf8_boundaries() {
+        let input = format!("{}🙂tail", "中".repeat(500));
+        let detail = truncate_chars(&input, 500);
+        assert_eq!(detail.chars().count(), 500);
+        assert_eq!(detail, "中".repeat(500));
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -25,7 +25,6 @@ use api::YoudaoClient;
 use app_state::SharedState;
 use bing_translate::BingTranslateClient;
 use builtin_translate::BuiltinTranslateClient;
-use llm_translate::LlmTranslateClient;
 use commands::{
     begin_capture, begin_copy_capture, cancel_capture, capture_debug_log, clear_history,
     clear_text_history, clear_translate_cache, close_overlay, hide_window, list_history,
@@ -33,8 +32,8 @@ use commands::{
     resize_main_window, save_settings, show_overlay, submit_capture_selection, translate_text,
 };
 use config::ConfigStore;
+use llm_translate::LlmTranslateClient;
 use models::TranslatorSettings;
-use translate_engine::TextTranslator;
 use tauri::{
     image::Image,
     menu::{MenuBuilder, MenuItemBuilder},
@@ -43,6 +42,8 @@ use tauri::{
 };
 use tauri_plugin_autostart::MacosLauncher;
 use tracing_subscriber::EnvFilter;
+use translate_cache::TranslateCache;
+use translate_engine::TextTranslator;
 
 /// Wire tracing to a rolling log file (in the app data dir) plus stderr.
 /// Release builds have no console attached (`windows_subsystem = "windows"`),
@@ -185,16 +186,30 @@ fn main() {
                         .build()?,
                 );
 
+                // LLM calls can legitimately take longer than the built-in
+                // engines. Their complete request/response timeout is enforced
+                // inside `LlmTranslateClient`, so do not reuse the 10s client.
+                let llm_http = std::sync::Arc::new(
+                    reqwest::Client::builder()
+                        .connect_timeout(std::time::Duration::from_secs(5))
+                        .build()?,
+                );
+
                 let api_client = YoudaoClient::new(general_http.clone());
                 let bing_client = BingTranslateClient::new(bing_http);
                 let builtin_client = BuiltinTranslateClient::new();
-                let llm_client = LlmTranslateClient::new(general_http);
+                let llm_client = LlmTranslateClient::new(llm_http);
                 let text_translator = TextTranslator::new(bing_client, builtin_client, llm_client);
+                let translate_cache = TranslateCache::new(config_store.translate_cache_path());
+                // Complete cache initialization before commands can access the
+                // shared state, eliminating load/insert/save startup races.
+                translate_cache.load().await;
                 app_handle.manage(SharedState::new(
                     config_store,
                     settings,
                     api_client,
                     text_translator,
+                    translate_cache,
                 ));
                 Ok::<(), error::AppError>(())
             })?;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -13,8 +13,10 @@ mod google_translate;
 mod llm_translate;
 mod models;
 mod popup_shortcut;
+mod secure;
 mod self_test;
 mod startup;
+mod translate_cache;
 mod translate_engine;
 
 use std::path::PathBuf;
@@ -26,9 +28,9 @@ use builtin_translate::BuiltinTranslateClient;
 use llm_translate::LlmTranslateClient;
 use commands::{
     begin_capture, begin_copy_capture, cancel_capture, capture_debug_log, clear_history,
-    close_overlay, hide_window, list_history, load_capture_payload, load_overlay_payload,
-    load_settings, resize_main_window, save_settings, show_overlay, submit_capture_selection,
-    translate_text,
+    clear_text_history, clear_translate_cache, close_overlay, hide_window, list_history,
+    list_text_history, load_capture_payload, load_overlay_payload, load_settings,
+    resize_main_window, save_settings, show_overlay, submit_capture_selection, translate_text,
 };
 use config::ConfigStore;
 use models::TranslatorSettings;
@@ -42,10 +44,46 @@ use tauri::{
 use tauri_plugin_autostart::MacosLauncher;
 use tracing_subscriber::EnvFilter;
 
+/// Wire tracing to a rolling log file (in the app data dir) plus stderr.
+/// Release builds have no console attached (`windows_subsystem = "windows"`),
+/// so without a file the logs would be lost entirely on Windows.
+fn setup_logging() {
+    let filter =
+        EnvFilter::from_default_env().add_directive("info".parse().unwrap());
+
+    if let Some(dir) = dirs_of_log_dir() {
+        let _ = std::fs::create_dir_all(&dir);
+        let appender = tracing_appender::rolling::daily(dir, "glance.log");
+        let (non_blocking, guard) = tracing_appender::non_blocking(appender);
+        // Keep the non-blocking guard alive for the process lifetime.
+        std::mem::forget(guard);
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_ansi(false)
+            .with_writer(non_blocking)
+            .init();
+    } else {
+        tracing_subscriber::fmt().with_env_filter(filter).init();
+    }
+}
+
+fn dirs_of_log_dir() -> Option<std::path::PathBuf> {
+    std::env::var_os("GLANCE_LOG_DIR")
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            // Same location as tauri's AppData dir on Windows:
+            // %APPDATA%\com.harukaon.glance\logs
+            let appdata = std::env::var_os("APPDATA")?;
+            Some(
+                std::path::PathBuf::from(appdata)
+                    .join("com.harukaon.glance")
+                    .join("logs"),
+            )
+        })
+}
+
 fn main() {
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env().add_directive("info".parse().unwrap()))
-        .init();
+    setup_logging();
 
     if self_test::should_run_capture_self_test() {
         match self_test::run_capture_self_test() {
@@ -126,6 +164,8 @@ fn main() {
                     reqwest::Client::builder()
                         .user_agent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
                         .default_headers(general_headers)
+                        .connect_timeout(std::time::Duration::from_secs(5))
+                        .timeout(std::time::Duration::from_secs(10))
                         .build()?,
                 );
 
@@ -140,6 +180,8 @@ fn main() {
                         .user_agent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
                         .default_headers(bing_headers)
                         .redirect(reqwest::redirect::Policy::none())
+                        .connect_timeout(std::time::Duration::from_secs(5))
+                        .timeout(std::time::Duration::from_secs(10))
                         .build()?,
                 );
 
@@ -214,6 +256,9 @@ fn main() {
             save_settings,
             list_history,
             clear_history,
+            clear_text_history,
+            clear_translate_cache,
+            list_text_history,
             begin_capture,
             begin_copy_capture,
             cancel_capture,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -51,6 +51,12 @@ pub struct LlmConfig {
     pub prompt: String,
     #[serde(default = "default_llm_auto_prompt")]
     pub auto_prompt: String,
+    #[serde(default = "default_llm_max_tokens")]
+    pub max_tokens: u32,
+}
+
+fn default_llm_max_tokens() -> u32 {
+    4096
 }
 
 fn default_llm_base_url() -> String {
@@ -87,6 +93,7 @@ impl Default for LlmConfig {
             model: default_llm_model(),
             prompt: default_llm_prompt(),
             auto_prompt: default_llm_auto_prompt(),
+            max_tokens: default_llm_max_tokens(),
         }
     }
 }
@@ -96,6 +103,8 @@ impl Default for LlmConfig {
 pub struct TranslatorSettings {
     pub from_lang: String,
     pub to_lang: String,
+    #[serde(default = "default_capture_to_lang")]
+    pub capture_to_lang: String,
     pub clientele: String,
     pub client: String,
     pub vendor: String,
@@ -114,6 +123,8 @@ pub struct TranslatorSettings {
     pub close_on_outside_click: bool,
     #[serde(default)]
     pub autostart: bool,
+    #[serde(default = "default_auto_translate")]
+    pub auto_translate: bool,
     #[serde(default = "default_hotkey")]
     pub hotkey: String,
     #[serde(default = "default_copy_hotkey")]
@@ -128,6 +139,18 @@ pub struct TranslatorSettings {
     pub proxy_mode: ProxyMode,
     #[serde(default)]
     pub custom_proxy: String,
+    #[serde(default = "default_history_limit")]
+    pub history_limit: usize,
+    #[serde(default = "default_cache_size")]
+    pub cache_size: usize,
+}
+
+fn default_history_limit() -> usize {
+    200
+}
+
+fn default_cache_size() -> usize {
+    200
 }
 
 impl Default for TranslatorSettings {
@@ -143,6 +166,7 @@ impl Default for TranslatorSettings {
         Self {
             from_lang: "auto".to_string(),
             to_lang: "zh-CHS".to_string(),
+            capture_to_lang: default_capture_to_lang(),
             clientele: "deskdict".to_string(),
             client: "deskdict".to_string(),
             vendor: "fanyiweb_navigation".to_string(),
@@ -165,6 +189,7 @@ impl Default for TranslatorSettings {
             overlay_font_scale: 1.0,
             close_on_outside_click: true,
             autostart: false,
+            auto_translate: default_auto_translate(),
             hotkey: default_hotkey(),
             copy_hotkey: default_copy_hotkey(),
             text_translate_engine: TextTranslateEngine::default(),
@@ -172,6 +197,8 @@ impl Default for TranslatorSettings {
             popup_shortcut: None,
             proxy_mode: ProxyMode::default(),
             custom_proxy: String::new(),
+            history_limit: default_history_limit(),
+            cache_size: default_cache_size(),
         }
     }
 }
@@ -208,6 +235,14 @@ fn default_hotkey() -> String {
 
 fn default_copy_hotkey() -> String {
     "CommandOrControl+Shift+C".to_string()
+}
+
+fn default_auto_translate() -> bool {
+    true
+}
+
+fn default_capture_to_lang() -> String {
+    "zh-CHS".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -289,6 +324,19 @@ pub struct TextTranslationResult {
     pub from_lang_detected: String,
     #[serde(default)]
     pub alternatives: Vec<String>,
+}
+
+/// One text-translation history entry (persisted in `text_history.json`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextHistoryItem {
+    pub id: String,
+    pub created_at: DateTime<Utc>,
+    pub from_lang: String,
+    pub to_lang: String,
+    pub engine: String,
+    pub source: String,
+    pub translated: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -326,6 +326,14 @@ pub struct TextTranslationResult {
     pub alternatives: Vec<String>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TextSourceSide {
+    #[default]
+    Left,
+    Right,
+}
+
 /// One text-translation history entry (persisted in `text_history.json`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -337,6 +345,8 @@ pub struct TextHistoryItem {
     pub engine: String,
     pub source: String,
     pub translated: String,
+    #[serde(default)]
+    pub source_side: TextSourceSide,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -396,5 +406,26 @@ impl TranslationHistoryItem {
             selection,
             pairs,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_text_history_defaults_to_left_source() {
+        let item: TextHistoryItem = serde_json::from_value(serde_json::json!({
+            "id": "legacy",
+            "createdAt": "2026-01-01T00:00:00Z",
+            "fromLang": "en",
+            "toLang": "zh-CHS",
+            "engine": "bing",
+            "source": "hello",
+            "translated": "你好"
+        }))
+        .unwrap();
+
+        assert_eq!(item.source_side, TextSourceSide::Left);
     }
 }

--- a/src-tauri/src/secure.rs
+++ b/src-tauri/src/secure.rs
@@ -1,0 +1,121 @@
+//! Encrypts the LLM API key at rest.
+//!
+//! On Windows the value is protected with the DPAPI
+//! (`CryptProtectData`/`CryptUnprotectData`), so it is only readable by the
+//! current Windows user account. Encrypted values are stored as
+//! `enc:v1:<base64>`. Values without the prefix are treated as legacy
+//! plaintext and returned unchanged (they get encrypted on the next save).
+//! On other platforms the value is stored as-is.
+
+/// Encrypt a plaintext secret for storage. Never fails: falls back to
+/// plaintext when DPAPI is unavailable (e.g. non-Windows or unusual setups).
+pub fn encrypt(value: &str) -> String {
+    #[cfg(target_os = "windows")]
+    {
+        if !value.is_empty() {
+            if let Some(enc) = encrypt_windows(value) {
+                return format!("enc:v1:{enc}");
+            }
+        }
+    }
+    value.to_string()
+}
+
+/// Decrypt a stored secret. Values that are not `enc:v1:` prefixed are
+/// returned as-is (legacy plaintext).
+pub fn decrypt(stored: &str) -> String {
+    if let Some(b64) = stored.strip_prefix("enc:v1:") {
+        #[cfg(target_os = "windows")]
+        {
+            if let Some(plain) = decrypt_windows(b64) {
+                return plain;
+            }
+        }
+        // Encrypted value but no decryptor available: return as-is rather
+        // than corrupting the secret.
+        return stored.to_string();
+    }
+    stored.to_string()
+}
+
+#[cfg(target_os = "windows")]
+fn encrypt_windows(plain: &str) -> Option<String> {
+    use base64::Engine;
+    use windows_sys::Win32::Foundation::{LocalFree, HLOCAL};
+    use windows_sys::Win32::Security::Cryptography::{
+        CryptProtectData, CRYPT_INTEGER_BLOB, CRYPTPROTECT_UI_FORBIDDEN,
+    };
+
+    let bytes = plain.as_bytes();
+    let mut in_blob = CRYPT_INTEGER_BLOB {
+        cbData: bytes.len() as u32,
+        pbData: bytes.as_ptr() as *mut u8,
+    };
+    let mut out_blob = CRYPT_INTEGER_BLOB {
+        cbData: 0,
+        pbData: std::ptr::null_mut(),
+    };
+
+    let ok = unsafe {
+        CryptProtectData(
+            &mut in_blob,
+            std::ptr::null_mut(),
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            CRYPTPROTECT_UI_FORBIDDEN,
+            &mut out_blob,
+        )
+    };
+    if ok == 0 {
+        return None;
+    }
+    let data = unsafe { std::slice::from_raw_parts(out_blob.pbData, out_blob.cbData as usize) };
+    let encoded = base64::engine::general_purpose::STANDARD.encode(data);
+    unsafe {
+        let _ = LocalFree(out_blob.pbData as HLOCAL);
+    }
+    Some(encoded)
+}
+
+#[cfg(target_os = "windows")]
+fn decrypt_windows(b64: &str) -> Option<String> {
+    use base64::Engine;
+    use windows_sys::Win32::Foundation::{LocalFree, HLOCAL};
+    use windows_sys::Win32::Security::Cryptography::{
+        CryptUnprotectData, CRYPT_INTEGER_BLOB, CRYPTPROTECT_UI_FORBIDDEN,
+    };
+
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(b64)
+        .ok()?;
+    let mut in_blob = CRYPT_INTEGER_BLOB {
+        cbData: bytes.len() as u32,
+        pbData: bytes.as_ptr() as *mut u8,
+    };
+    let mut out_blob = CRYPT_INTEGER_BLOB {
+        cbData: 0,
+        pbData: std::ptr::null_mut(),
+    };
+
+    let ok = unsafe {
+        CryptUnprotectData(
+            &mut in_blob,
+            std::ptr::null_mut(),
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            CRYPTPROTECT_UI_FORBIDDEN,
+            &mut out_blob,
+        )
+    };
+    if ok == 0 {
+        return None;
+    }
+    let data = unsafe { std::slice::from_raw_parts(out_blob.pbData, out_blob.cbData as usize) };
+    let text = String::from_utf8(data.to_vec()).ok();
+    unsafe {
+        let _ = LocalFree(out_blob.pbData as HLOCAL);
+    }
+    text
+}

--- a/src-tauri/src/translate_cache.rs
+++ b/src-tauri/src/translate_cache.rs
@@ -12,14 +12,14 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 
-use crate::models::TextTranslationResult;
+use crate::models::{LlmConfig, TextTranslateEngine, TextTranslationResult};
 
 /// Skip caching very large inputs so the cache file stays small.
 const MAX_CACHED_TEXT_LEN: usize = 4096;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CacheEntry {
-    /// sha256 hex of `text|from|to|engine|model`.
+    /// sha256 hex of `text|from|to|engine|configuration variant`.
     key: String,
     result: TextTranslationResult,
     /// Unix timestamp (seconds) of the last access, used for eviction.
@@ -71,12 +71,12 @@ impl TranslateCache {
         from: &str,
         to: &str,
         engine: &str,
-        model: &str,
+        variant: &str,
     ) -> Option<TextTranslationResult> {
         if text.len() > MAX_CACHED_TEXT_LEN {
             return None;
         }
-        let cache_key = make_key(text, from, to, engine, model);
+        let cache_key = make_key(text, from, to, engine, variant);
         let mut state = self.inner.lock().await;
         let now = now_secs();
         let mut hit = false;
@@ -106,7 +106,7 @@ impl TranslateCache {
         from: &str,
         to: &str,
         engine: &str,
-        model: &str,
+        variant: &str,
         result: TextTranslationResult,
     ) {
         if text.len() > MAX_CACHED_TEXT_LEN {
@@ -118,7 +118,7 @@ impl TranslateCache {
         if result.translated_text.trim() == text.trim() {
             return;
         }
-        let cache_key = make_key(text, from, to, engine, model);
+        let cache_key = make_key(text, from, to, engine, variant);
         let mut state = self.inner.lock().await;
         if let Some(entry) = state.entries.iter_mut().find(|e| e.key == cache_key) {
             entry.result = result;
@@ -194,8 +194,12 @@ impl TranslateCache {
     }
 }
 
-fn make_key(text: &str, from: &str, to: &str, engine: &str, model: &str) -> String {
+fn make_key(text: &str, from: &str, to: &str, engine: &str, variant: &str) -> String {
     let mut hasher = Sha256::new();
+    // Version the key so older entries that omitted effective LLM settings can
+    // never be served after an upgrade.
+    hasher.update(b"glance-translation-cache-v2");
+    hasher.update([0u8]);
     hasher.update(text.as_bytes());
     hasher.update([0u8]);
     hasher.update(from.as_bytes());
@@ -204,7 +208,30 @@ fn make_key(text: &str, from: &str, to: &str, engine: &str, model: &str) -> Stri
     hasher.update([0u8]);
     hasher.update(engine.as_bytes());
     hasher.update([0u8]);
-    hasher.update(model.as_bytes());
+    hasher.update(variant.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+/// Settings that can change an LLM translation's output. The API key is
+/// deliberately excluded: credentials do not affect translation semantics.
+pub fn configuration_variant(engine: TextTranslateEngine, llm: &LlmConfig) -> String {
+    if engine != TextTranslateEngine::Llm {
+        return String::new();
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(b"llm-configuration-v1");
+    for value in [
+        llm.base_url.trim(),
+        llm.model.trim(),
+        llm.prompt.as_str(),
+        llm.auto_prompt.as_str(),
+    ] {
+        hasher.update([0u8]);
+        hasher.update(value.as_bytes());
+    }
+    hasher.update([0u8]);
+    hasher.update(llm.max_tokens.to_le_bytes());
     format!("{:x}", hasher.finalize())
 }
 
@@ -213,4 +240,47 @@ fn now_secs() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn llm_configuration_changes_invalidate_cache_variant() {
+        let base = LlmConfig::default();
+        let base_variant = configuration_variant(TextTranslateEngine::Llm, &base);
+
+        let mut cases = Vec::new();
+        let mut changed = base.clone();
+        changed.base_url.push_str("/other");
+        cases.push(changed);
+        let mut changed = base.clone();
+        changed.model.push_str("-other");
+        cases.push(changed);
+        let mut changed = base.clone();
+        changed.prompt.push_str(" Be concise.");
+        cases.push(changed);
+        let mut changed = base.clone();
+        changed.auto_prompt.push_str(" Be concise.");
+        cases.push(changed);
+        let mut changed = base.clone();
+        changed.max_tokens += 1;
+        cases.push(changed);
+
+        for changed in cases {
+            assert_ne!(
+                base_variant,
+                configuration_variant(TextTranslateEngine::Llm, &changed)
+            );
+        }
+    }
+
+    #[test]
+    fn non_llm_engines_ignore_llm_configuration() {
+        assert_eq!(
+            configuration_variant(TextTranslateEngine::Bing, &LlmConfig::default()),
+            ""
+        );
+    }
 }

--- a/src-tauri/src/translate_cache.rs
+++ b/src-tauri/src/translate_cache.rs
@@ -1,0 +1,216 @@
+//! Exact-match, persisted LRU cache for text translations.
+//!
+//! The key is the full source text + language pair + engine (+ model), so a
+//! hit only happens when the exact same query was translated before — the
+//! cached result is identical to what a fresh request would return. This is
+//! purely a latency/cost optimization, never a quality one: partial or fuzzy
+//! matches are deliberately not supported.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::sync::Mutex;
+
+use crate::models::TextTranslationResult;
+
+/// Skip caching very large inputs so the cache file stays small.
+const MAX_CACHED_TEXT_LEN: usize = 4096;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CacheEntry {
+    /// sha256 hex of `text|from|to|engine|model`.
+    key: String,
+    result: TextTranslationResult,
+    /// Unix timestamp (seconds) of the last access, used for eviction.
+    last_used: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct CacheFile {
+    entries: Vec<CacheEntry>,
+}
+
+pub struct TranslateCache {
+    path: PathBuf,
+    inner: Mutex<CacheState>,
+}
+
+struct CacheState {
+    entries: Vec<CacheEntry>,
+    max_entries: usize,
+    dirty: bool,
+}
+
+impl TranslateCache {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            inner: Mutex::new(CacheState {
+                entries: Vec::new(),
+                max_entries: 200,
+                dirty: false,
+            }),
+        }
+    }
+
+    pub async fn load(&self) {
+        let mut state = self.inner.lock().await;
+        match tokio::fs::read(&self.path).await {
+            Ok(bytes) => match serde_json::from_slice::<CacheFile>(&bytes) {
+                Ok(file) => state.entries = file.entries,
+                Err(err) => tracing::warn!("translate cache load failed: {err}"),
+            },
+            Err(_) => {} // no cache file yet
+        }
+    }
+
+    pub async fn get(
+        &self,
+        text: &str,
+        from: &str,
+        to: &str,
+        engine: &str,
+        model: &str,
+    ) -> Option<TextTranslationResult> {
+        if text.len() > MAX_CACHED_TEXT_LEN {
+            return None;
+        }
+        let cache_key = make_key(text, from, to, engine, model);
+        let mut state = self.inner.lock().await;
+        let now = now_secs();
+        let mut hit = false;
+        if let Some(entry) = state.entries.iter_mut().find(|e| e.key == cache_key) {
+            // Defensive: never serve a stale "identity" entry (the model once
+            // echoed the input back). Treat it as a miss and drop it so the
+            // request goes out again.
+            if entry.result.translated_text.trim() == text.trim() {
+                state.entries.retain(|e| e.key != cache_key);
+                state.dirty = true;
+            } else {
+                entry.last_used = now;
+                hit = true;
+            }
+        }
+        if hit {
+            state.dirty = true;
+            let entry = state.entries.iter().find(|e| e.key == cache_key);
+            return entry.map(|e| e.result.clone());
+        }
+        None
+    }
+
+    pub async fn insert(
+        &self,
+        text: &str,
+        from: &str,
+        to: &str,
+        engine: &str,
+        model: &str,
+        result: TextTranslationResult,
+    ) {
+        if text.len() > MAX_CACHED_TEXT_LEN {
+            return;
+        }
+        // Never cache an identity result (model echoed the input): it is
+        // almost always a direction/mismatch artifact, and caching it would
+        // poison every later request for the same text.
+        if result.translated_text.trim() == text.trim() {
+            return;
+        }
+        let cache_key = make_key(text, from, to, engine, model);
+        let mut state = self.inner.lock().await;
+        if let Some(entry) = state.entries.iter_mut().find(|e| e.key == cache_key) {
+            entry.result = result;
+            entry.last_used = now_secs();
+            state.dirty = true;
+            return;
+        }
+        state.entries.push(CacheEntry {
+            key: cache_key,
+            result,
+            last_used: now_secs(),
+        });
+        // Evict the least recently used entry when over the cap.
+        while state.entries.len() > state.max_entries {
+            let mut oldest = 0usize;
+            for (i, e) in state.entries.iter().enumerate() {
+                if e.last_used < state.entries[oldest].last_used {
+                    oldest = i;
+                }
+            }
+            state.entries.swap_remove(oldest);
+        }
+        state.dirty = true;
+    }
+
+    pub async fn set_max_entries(&self, max: usize) {
+        let mut state = self.inner.lock().await;
+        let max = max.max(1);
+        state.max_entries = max;
+        while state.entries.len() > max {
+            let mut oldest = 0usize;
+            for (i, e) in state.entries.iter().enumerate() {
+                if e.last_used < state.entries[oldest].last_used {
+                    oldest = i;
+                }
+            }
+            state.entries.swap_remove(oldest);
+        }
+        state.dirty = true;
+    }
+
+    pub async fn clear(&self) {
+        let mut state = self.inner.lock().await;
+        state.entries.clear();
+        state.dirty = true;
+    }
+
+    pub async fn entry_count(&self) -> usize {
+        self.inner.lock().await.entries.len()
+    }
+
+    /// Persist the cache to disk if anything changed. Cheap to call often:
+    /// it's a no-op when clean.
+    pub async fn save(&self) {
+        let mut state = self.inner.lock().await;
+        if !state.dirty {
+            return;
+        }
+        let bytes = match serde_json::to_vec(&CacheFile {
+            entries: state.entries.clone(),
+        }) {
+            Ok(b) => b,
+            Err(err) => {
+                tracing::warn!("translate cache serialize failed: {err}");
+                return;
+            }
+        };
+        if let Err(err) = tokio::fs::write(&self.path, bytes).await {
+            tracing::warn!("translate cache save failed: {err}");
+            return;
+        }
+        state.dirty = false;
+    }
+}
+
+fn make_key(text: &str, from: &str, to: &str, engine: &str, model: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(text.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(from.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(to.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(engine.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(model.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}

--- a/src-tauri/src/translate_engine.rs
+++ b/src-tauri/src/translate_engine.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::bing_translate::BingTranslateClient;
 use crate::builtin_translate::BuiltinTranslateClient;
@@ -12,6 +13,11 @@ pub struct TextTranslator {
     builtin: Arc<BuiltinTranslateClient>,
     llm: Arc<LlmTranslateClient>,
 }
+
+/// How many times a transient failure (timeout, 5xx, 429, network) retries the
+/// primary engine before falling back.
+const MAX_RETRIES: u32 = 2;
+const RETRY_BASE_DELAY_MS: u64 = 300;
 
 impl TextTranslator {
     pub fn new(
@@ -27,6 +33,49 @@ impl TextTranslator {
     }
 
     pub async fn translate(
+        &self,
+        text: &str,
+        from: &str,
+        to: &str,
+        engine: TextTranslateEngine,
+        llm_config: &LlmConfig,
+        proxy: Option<&str>,
+    ) -> AppResult<TextTranslationResult> {
+        // Retry transient failures on the primary engine with a small backoff.
+        let mut attempt = 0;
+        let primary_err = loop {
+            match self.translate_once(text, from, to, engine, llm_config, proxy).await {
+                Ok(result) => return Ok(result),
+                Err(err) if err.is_transient() && attempt < MAX_RETRIES => {
+                    attempt += 1;
+                    tracing::warn!(
+                        "engine {engine:?} transient failure (attempt {attempt}): {err}"
+                    );
+                    tokio::time::sleep(Duration::from_millis(
+                        RETRY_BASE_DELAY_MS * (attempt as u64),
+                    ))
+                    .await;
+                }
+                Err(err) => break err,
+            }
+        };
+
+        // Retries exhausted: degrade to a free fallback engine so the user
+        // still gets a result. Never fall back *to* the LLM (it costs money).
+        if let Some(fallback) = fallback_engine(engine) {
+            tracing::warn!("engine {engine:?} failed, falling back to {fallback:?}: {primary_err}");
+            let mut result = self
+                .translate_once(text, from, to, fallback, llm_config, proxy)
+                .await?;
+            result
+                .alternatives
+                .push("⚠ 主引擎不可用，已自动使用备用引擎".to_string());
+            return Ok(result);
+        }
+        Err(primary_err)
+    }
+
+    async fn translate_once(
         &self,
         text: &str,
         from: &str,
@@ -53,9 +102,25 @@ impl TextTranslator {
                         &llm_config.model,
                         &llm_config.prompt,
                         &llm_config.auto_prompt,
+                        (llm_config.max_tokens > 0).then_some(llm_config.max_tokens),
                     )
                     .await
             }
         }
+    }
+}
+
+/// Backup engine used when the configured engine fails after retries.
+/// Both candidates are key-free engines; LLM is intentionally excluded.
+fn fallback_engine(engine: TextTranslateEngine) -> Option<TextTranslateEngine> {
+    match engine {
+        TextTranslateEngine::Bing => Some(TextTranslateEngine::Google),
+        TextTranslateEngine::Llm | TextTranslateEngine::Google => {
+            Some(TextTranslateEngine::Bing)
+        }
+        TextTranslateEngine::Microsoft
+        | TextTranslateEngine::Transmart
+        | TextTranslateEngine::Yandex
+        | TextTranslateEngine::Iciba => Some(TextTranslateEngine::Bing),
     }
 }

--- a/src-tauri/src/translate_engine.rs
+++ b/src-tauri/src/translate_engine.rs
@@ -14,6 +14,11 @@ pub struct TextTranslator {
     llm: Arc<LlmTranslateClient>,
 }
 
+pub struct TranslationOutcome {
+    pub result: TextTranslationResult,
+    pub engine: TextTranslateEngine,
+}
+
 /// How many times a transient failure (timeout, 5xx, 429, network) retries the
 /// primary engine before falling back.
 const MAX_RETRIES: u32 = 2;
@@ -40,12 +45,15 @@ impl TextTranslator {
         engine: TextTranslateEngine,
         llm_config: &LlmConfig,
         proxy: Option<&str>,
-    ) -> AppResult<TextTranslationResult> {
+    ) -> AppResult<TranslationOutcome> {
         // Retry transient failures on the primary engine with a small backoff.
         let mut attempt = 0;
         let primary_err = loop {
-            match self.translate_once(text, from, to, engine, llm_config, proxy).await {
-                Ok(result) => return Ok(result),
+            match self
+                .translate_once(text, from, to, engine, llm_config, proxy)
+                .await
+            {
+                Ok(result) => return Ok(TranslationOutcome { result, engine }),
                 Err(err) if err.is_transient() && attempt < MAX_RETRIES => {
                     attempt += 1;
                     tracing::warn!(
@@ -70,7 +78,10 @@ impl TextTranslator {
             result
                 .alternatives
                 .push("⚠ 主引擎不可用，已自动使用备用引擎".to_string());
-            return Ok(result);
+            return Ok(TranslationOutcome {
+                result,
+                engine: fallback,
+            });
         }
         Err(primary_err)
     }
@@ -115,9 +126,7 @@ impl TextTranslator {
 fn fallback_engine(engine: TextTranslateEngine) -> Option<TextTranslateEngine> {
     match engine {
         TextTranslateEngine::Bing => Some(TextTranslateEngine::Google),
-        TextTranslateEngine::Llm | TextTranslateEngine::Google => {
-            Some(TextTranslateEngine::Bing)
-        }
+        TextTranslateEngine::Llm | TextTranslateEngine::Google => Some(TextTranslateEngine::Bing),
         TextTranslateEngine::Microsoft
         | TextTranslateEngine::Transmart
         | TextTranslateEngine::Yandex

--- a/ui/app.js
+++ b/ui/app.js
@@ -36,6 +36,74 @@ const PROXY_MODES = [
   { value: "none", label: "不使用" }
 ];
 
+// LLM prompt presets — 两个可组合维度：风格（通用） + 行业。
+// 选择后生成指定源语言 / 自动检测源语言两套提示词并覆盖保存。
+const LLM_STYLE_PRESETS = [
+  { value: "general", label: "通用翻译", clause: "" },
+  { value: "concise", label: "简洁翻译", clause: "Be concise: keep the meaning faithful." },
+  { value: "casual", label: "口语化", clause: "Translate into natural, colloquial everyday language, keeping the tone casual and idiomatic." },
+  { value: "formal", label: "正式书面", clause: "Use formal written style with precise, standard vocabulary." }
+];
+
+const LLM_INDUSTRY_PRESETS = [
+  { value: "none", label: "不限行业", role: "translator", clause: "" },
+  { value: "tech", label: "IT 技术", role: "translator specializing in IT", clause: "Keep technical terms accurate and consistent with common industry usage (e.g. keep terms like API, SDK, JSON where appropriate)." },
+  { value: "legal", label: "法律", role: "legal translator", clause: "Use precise legal terminology and keep the sentence structure faithful to the legal register." },
+  { value: "medical", label: "医学", role: "medical translator", clause: "Use accurate medical terminology (anatomy, drug and clinical terms) and keep dosage and numbers exact." },
+  { value: "finance", label: "金融", role: "financial translator", clause: "Use standard financial and accounting terminology. Keep numbers, currency, percentages and dates exact." },
+  { value: "academic", label: "学术论文", role: "academic translator", clause: "Maintain the academic register, precise argumentation, and consistent technical terms and citations." },
+  { value: "business", label: "商务邮件", role: "business communication translator", clause: "Translate into professional, courteous business correspondence with a clear and polite tone." },
+  { value: "marketing", label: "市场营销", role: "marketing copy translator", clause: "Translate into natural, engaging marketing copy, adapting idioms and cultural references while preserving the brand voice." }
+];
+
+const PRESET_CUSTOM = "custom";
+
+function buildPresetPrompts(styleVal, industryVal) {
+  const style = LLM_STYLE_PRESETS.find(s => s.value === styleVal) || LLM_STYLE_PRESETS[0];
+  const ind = LLM_INDUSTRY_PRESETS.find(i => i.value === industryVal) || LLM_INDUSTRY_PRESETS[0];
+  const extra = [ind.clause, style.clause].filter(Boolean).join(" ");
+  const tail = extra ? ` ${extra} Output only the translation, nothing else. Do not add explanations or notes.` : " Output only the translation, nothing else. Do not add explanations or notes.";
+  return {
+    prompt: `You are a professional ${ind.role}. Translate the following text from {from} to {to}.${tail}`,
+    autoPrompt: `You are a professional ${ind.role}. Detect the source language and translate the following text to {to}.${tail}`
+  };
+}
+
+// Find which (style, industry) combo produced the current prompts, or null.
+function presetComboFor(prompt, autoPrompt) {
+  const p = (prompt || "").trim();
+  const a = (autoPrompt || "").trim();
+  for (const s of LLM_STYLE_PRESETS) {
+    for (const i of LLM_INDUSTRY_PRESETS) {
+      const built = buildPresetPrompts(s.value, i.value);
+      if (built.prompt === p && built.autoPrompt === a) return { style: s.value, industry: i.value };
+    }
+  }
+  return null;
+}
+
+function presetSelectOptions(list, current, withCustom) {
+  return list.map(x =>
+    `<option value="${x.value}" ${x.value === current ? "selected" : ""}>${escapeHtml(x.label)}</option>`
+  ).join("") + (withCustom ? `<option value="${PRESET_CUSTOM}" ${current === PRESET_CUSTOM ? "selected" : ""}>自定义</option>` : "");
+}
+
+// Auto-expand the advanced prompt editor when the user is already on custom
+// prompts (so their customizations stay discoverable).
+function llmAdvancedExpanded() {
+  const cfg = state.settings?.llmConfig;
+  if (!cfg) return false;
+  return presetComboFor(cfg.prompt, cfg.autoPrompt) === null;
+}
+
+// Current combo (or "custom") for the two preset selects.
+function presetComboCurrent() {
+  const cfg = state.settings?.llmConfig;
+  if (!cfg) return { style: PRESET_CUSTOM, industry: PRESET_CUSTOM };
+  const combo = presetComboFor(cfg.prompt, cfg.autoPrompt);
+  return combo || { style: PRESET_CUSTOM, industry: PRESET_CUSTOM };
+}
+
 // Measure the height the window needs to fit the whole app content (header +
 // translation area + settings panel) without leaving blank space.
 //
@@ -95,18 +163,19 @@ let translateSeq = 0;
 function debouncedTranslate() {
   if (debounceTimer) clearTimeout(debounceTimer);
   debounceTimer = setTimeout(() => {
-    const text = state.inputText.trim();
+    const source = state.activeSide === "right" ? state.rightText : state.leftText;
+    const text = (source || "").trim();
     if (text) {
-      translateText();
+      translateText(state.activeSide === "right" ? "right" : "left");
     } else {
-      // Input cleared: cancel any in-flight result and reset the output.
+      // Source cleared: cancel any in-flight result and reset the output side.
       translateSeq++;
       state.textLoading = false;
-      state.translatedText = "";
       state.alternatives = [];
       state.detectedLang = "";
-      updateOutputArea();
-      updateDetectedLang();
+      if (state.activeSide === "right") state.leftText = "";
+      else state.rightText = "";
+      updateSides();
     }
   }, 500);
 }
@@ -124,20 +193,23 @@ const state = {
   statusType: "",
   loading: false,
   listenersBound: false,
-  inputText: "",
-  translatedText: "",
+  leftText: "",
+  rightText: "",
+  activeSide: "left",
   alternatives: [],
   textLoading: false,
   detectedLang: "",
   ttsPlaying: false,
   hotkeyRecording: false,
-  settingsOpen: false
+  settingsOpen: false,
+  textHistoryCache: []
 };
 
 function defaultSettings() {
   return {
     fromLang: "auto",
     toLang: "zh-CHS",
+    captureToLang: "zh-CHS",
     clientele: "deskdict",
     client: "deskdict",
     vendor: "fanyiweb_navigation",
@@ -163,11 +235,14 @@ function defaultSettings() {
       apiKey: "",
       model: "gpt-4o-mini",
       prompt: "You are a professional translator. Translate the following text from {from} to {to}. Only output the translation, nothing else. Do not add explanations or notes.",
-      autoPrompt: "You are a professional translator. Detect the source language and translate the following text to {to}. Only output the translation, nothing else. Do not add explanations or notes."
+      autoPrompt: "You are a professional translator. Detect the source language and translate the following text to {to}. Only output the translation, nothing else. Do not add explanations or notes.",
+      maxTokens: 4096
     },
     popupShortcut: null,
     proxyMode: "system",
-    customProxy: ""
+    customProxy: "",
+    historyLimit: 200,
+    cacheSize: 200
   };
 }
 
@@ -176,6 +251,22 @@ function defaultSettings() {
 function escapeHtml(v) {
   return String(v).replaceAll("&","&amp;").replaceAll("<","&lt;").replaceAll(">","&gt;")
     .replaceAll('"',"&quot;").replaceAll("'","&#39;");
+}
+
+// 粘贴：严格按“粘到哪一侧，哪一侧就是源”的语义处理，不做方向猜测。
+// 方向规则：左侧输入 → 左侧为源，右侧输出 {toLang} 译文；
+//           右侧输入 → 右侧为源，左侧输出 {fromLang} 译文。
+// 语言错配/混合文本由 LLM 提示词硬规则兜底，不再做前端方向纠正。
+function handlePaste(side, value) {
+  if (!value) return; // 空值不处理，避免覆盖已有文本
+  if (side === "left") {
+    state.leftText = value;
+    state.activeSide = "left";
+  } else {
+    state.rightText = value;
+    state.activeSide = "right";
+  }
+  translateText(side);
 }
 
 function delay(ms) { return new Promise(r => setTimeout(r, ms)); }
@@ -193,10 +284,20 @@ function setCapturePreparing(active) {
   document.body.classList.toggle("capture-preparing", active);
 }
 
-function languageOptions(current) {
-  return LANGUAGES.map(l =>
-    `<option value="${l.value}" ${l.value === current ? "selected" : ""}>${l.label}</option>`
+function languageOptions(current, autoDisabled, hideAuto) {
+  return LANGUAGES.filter(l => !(hideAuto && l.value === "auto")).map(l =>
+    `<option value="${l.value}" ${l.value === current ? "selected" : ""}${l.value === "auto" && autoDisabled ? " disabled" : ""}>${l.label}</option>`
   ).join("");
+}
+
+// Re-render the two language dropdowns preserving their current values. The
+// "自动检测" option of one side is disabled when the other side is set to it,
+// since both sides can't be "auto" at the same time.
+function refreshLangSelects() {
+  const from = document.querySelector("#from-lang");
+  const to = document.querySelector("#to-lang");
+  if (from) from.innerHTML = languageOptions(from.value, state.settings?.toLang === "auto");
+  if (to) to.innerHTML = languageOptions(to.value, state.settings?.fromLang === "auto");
 }
 
 function shortcutKeysHtml(hk) {
@@ -243,13 +344,13 @@ async function bindMainListeners() {
     if (!p.busy && (!p.message || p.type === "error")) {
       setCapturePreparing(false);
     }
-    updateOutputArea();
+    updateSides();
   });
   await listen("main:focus-text-input", () => {
     focusTextInputIfAllowed({
       mode,
       hotkeyRecording: state.hotkeyRecording,
-      input: document.querySelector("#text-input"),
+      input: document.querySelector(state.activeSide === "right" ? "#text-input-right" : "#text-input"),
     });
   });
   state.listenersBound = true;
@@ -269,13 +370,17 @@ function renderMain() {
         <div class="header-left">
           <div class="app-title">Glance</div>
           <div class="lang-pill">
-            <select id="from-lang">${languageOptions(state.settings.fromLang)}</select>
+            <select id="from-lang">${languageOptions(state.settings.fromLang, state.settings.toLang === "auto")}</select>
             <span class="lang-icon">➔</span>
-            <select id="to-lang">${languageOptions(state.settings.toLang)}</select>
+            <select id="to-lang">${languageOptions(state.settings.toLang, state.settings.fromLang === "auto")}</select>
           </div>
         </div>
         <div class="header-right">
           <button class="capture-btn" id="capture-btn" title="截图翻译">⛶ 截图翻译</button>
+          <div class="lang-pill capture-pill" title="截图翻译目标语言">
+            <span class="lang-icon">⛶</span>
+            <select id="capture-to-lang">${languageOptions(state.settings.captureToLang, true, true)}</select>
+          </div>
           <button class="settings-btn" id="settings-btn" title="设置">⚙</button>
         </div>
       </div>
@@ -287,71 +392,94 @@ function renderMain() {
           </div>
           <div class="meta-info">
             <span class="detect-tag" id="detected-lang" style="display:none"></span>
-            <button class="tts-btn ${state.ttsPlaying ? "speaking" : ""}" id="tts-btn" title="朗读">🔊</button>
+            <span class="status-text" id="status-left" style="display:none"></span>
+            <span class="output-alternatives" id="alternatives-left" style="display:none"></span>
+            <button class="tts-btn" id="tts-btn" title="朗读">🔊</button>
           </div>
         </div>
         <div class="text-col output-col">
-          <div class="output-wrap" id="output-wrap">
-            <div class="output-primary" id="output-primary"></div>
-            <div class="output-alternatives" id="output-alternatives"></div>
+          <div class="input-wrap">
+            <textarea class="input-area" id="text-input-right" placeholder="输入要翻译的文本..." rows="3"></textarea>
+          </div>
+          <div class="meta-info">
+            <span class="detect-tag" id="detected-lang-right" style="display:none"></span>
+            <span class="status-text" id="status-right" style="display:none"></span>
+            <span class="output-alternatives" id="alternatives-right" style="display:none"></span>
+            <button class="tts-btn" id="tts-btn-right" title="朗读">🔊</button>
           </div>
         </div>
       </div>
 
       <div class="settings-panel" id="settings-panel" style="${state.settingsOpen ? "" : "display:none"}">
         <div class="settings-section">
-          <div class="settings-row">
-            <span class="settings-label">翻译引擎</span>
-            <div class="engine-switcher" id="engine-switcher">
-              ${TRANSLATE_ENGINES.map(e =>
-                `<button class="engine-btn ${state.settings.textTranslateEngine === e.value ? "active" : ""}" data-engine="${e.value}">${e.label}</button>`
-              ).join("")}
+          <button class="section-header" id="sec-translate-toggle" type="button">
+            <span class="section-arrow">▾</span> 翻译设置
+          </button>
+          <div class="section-body" id="sec-translate-body">
+            <div class="settings-row">
+              <span class="settings-label">翻译引擎</span>
+              <div class="engine-switcher" id="engine-switcher">
+                ${TRANSLATE_ENGINES.map(e =>
+                  `<button class="engine-btn ${state.settings.textTranslateEngine === e.value ? "active" : ""}" data-engine="${e.value}">${e.label}</button>`
+                ).join("")}
+              </div>
+            </div>
+            <div class="settings-row">
+              <span class="settings-label">网络代理</span>
+              <div class="engine-switcher" id="proxy-switcher">
+                ${PROXY_MODES.map(p =>
+                  `<button class="engine-btn ${state.settings.proxyMode === p.value ? "active" : ""}" data-proxy="${p.value}">${p.label}</button>`
+                ).join("")}
+              </div>
+            </div>
+            <div class="settings-row" id="custom-proxy-row" style="${state.settings.proxyMode === "custom" ? "" : "display:none"}">
+              <span class="settings-label">代理地址</span>
+              <input class="settings-input" id="custom-proxy" type="text"
+                      value="${escapeHtml(state.settings.customProxy || "")}"
+                      placeholder="http://127.0.0.1:7890" />
             </div>
           </div>
-          <div class="settings-row">
-            <span class="settings-label">网络代理</span>
-            <div class="engine-switcher" id="proxy-switcher">
-              ${PROXY_MODES.map(p =>
-                `<button class="engine-btn ${state.settings.proxyMode === p.value ? "active" : ""}" data-proxy="${p.value}">${p.label}</button>`
-              ).join("")}
+        </div>
+        <div class="settings-section">
+          <button class="section-header" id="sec-general-toggle" type="button">
+            <span class="section-arrow">▸</span> 通用设置
+          </button>
+          <div class="section-body" id="sec-general-body" style="display:none">
+            <div class="settings-row">
+              <span class="settings-label">开机自启</span>
+              <button class="toggle ${state.settings.autostart ? "on" : ""}" id="autostart" aria-pressed="${state.settings.autostart}"></button>
             </div>
-          </div>
-          <div class="settings-row" id="custom-proxy-row" style="${state.settings.proxyMode === "custom" ? "" : "display:none"}">
-            <span class="settings-label">代理地址</span>
-            <input class="settings-input" id="custom-proxy" type="text"
-                    value="${escapeHtml(state.settings.customProxy || "")}"
-                    placeholder="http://127.0.0.1:7890" />
-          </div>
-          <div class="settings-row">
-            <span class="settings-label">开机自启</span>
-            <button class="toggle ${state.settings.autostart ? "on" : ""}" id="autostart" aria-pressed="${state.settings.autostart}"></button>
-          </div>
-          <div class="settings-row">
-            <span class="settings-label">截图翻译</span>
-            <div class="shortcut-row settings-shortcut" id="shortcut-row">
-              快捷键: ${state.settings.hotkey ? shortcutKeysHtml(state.settings.hotkey) : "未设置"} <span class="shortcut-hint">点击可设置</span>
+            <div class="settings-row">
+              <span class="settings-label">截图翻译</span>
+              <div class="shortcut-row settings-shortcut" id="shortcut-row">
+                快捷键: ${state.settings.hotkey ? shortcutKeysHtml(state.settings.hotkey) : "未设置"} <span class="shortcut-hint">点击可设置</span>
+              </div>
             </div>
-          </div>
-          <div class="settings-row">
-            <span class="settings-label">截图复制</span>
-            <div class="shortcut-row settings-shortcut" id="copy-shortcut-row">
-              快捷键: ${state.settings.copyHotkey ? shortcutKeysHtml(state.settings.copyHotkey) : "未设置"} <span class="shortcut-hint">点击可设置</span>
+            <div class="settings-row">
+              <span class="settings-label">截图复制</span>
+              <div class="shortcut-row settings-shortcut" id="copy-shortcut-row">
+                快捷键: ${state.settings.copyHotkey ? shortcutKeysHtml(state.settings.copyHotkey) : "未设置"} <span class="shortcut-hint">点击可设置</span>
+              </div>
             </div>
-          </div>
-          <div class="settings-row">
-            <span class="settings-label">弹出窗口</span>
-            <div class="shortcut-row settings-shortcut" id="popup-shortcut-row">
-              ${state.settings.popupShortcut ? shortcutKeysHtml(state.settings.popupShortcut) : "未设置"} <span class="shortcut-hint">点击可设置</span>
+            <div class="settings-row">
+              <span class="settings-label">弹出窗口</span>
+              <div class="shortcut-row settings-shortcut" id="popup-shortcut-row">
+                ${state.settings.popupShortcut ? shortcutKeysHtml(state.settings.popupShortcut) : "未设置"} <span class="shortcut-hint">点击可设置</span>
+              </div>
             </div>
           </div>
         </div>
         <div class="settings-section" id="llm-settings" style="${state.settings.textTranslateEngine === "llm" ? "" : "display:none"}">
-          <div class="settings-row">
-            <span class="settings-label">API 地址 (OpenAI)</span>
-            <input class="settings-input" id="llm-base-url" type="text"
-                    value="${escapeHtml(state.settings.llmConfig.baseUrl)}"
-                    placeholder="https://api.openai.com/v1/chat/completions" />
-          </div>
+          <button class="section-header" id="sec-llm-toggle" type="button">
+            <span class="section-arrow">▾</span> AI 大模型
+          </button>
+          <div class="section-body" id="sec-llm-body">
+            <div class="settings-row">
+              <span class="settings-label">API 地址 (OpenAI)</span>
+              <input class="settings-input" id="llm-base-url" type="text"
+                      value="${escapeHtml(state.settings.llmConfig.baseUrl)}"
+                      placeholder="https://api.openai.com/v1/chat/completions" />
+            </div>
           <div class="settings-row">
             <span class="settings-label">API Key</span>
             <input class="settings-input" id="llm-api-key" type="password"
@@ -364,19 +492,81 @@ function renderMain() {
                     value="${escapeHtml(state.settings.llmConfig.model)}"
                     placeholder="gpt-4o-mini" />
           </div>
-          <div class="settings-row settings-row-vertical">
-            <span class="settings-label">提示词（指定源语言）
-              <span class="settings-hint">可用 {from} / {to} 表示源/目标语言</span>
-            </span>
-            <textarea class="settings-input settings-textarea" id="llm-prompt" rows="4"
-                    placeholder="${escapeHtml(defaultSettings().llmConfig.prompt)}">${escapeHtml(state.settings.llmConfig.prompt || "")}</textarea>
+          <div class="settings-row">
+            <span class="settings-label">最大输出 Tokens</span>
+            <input class="settings-input" id="llm-max-tokens" type="number" min="1"
+                    value="${escapeHtml(state.settings.llmConfig.maxTokens || 4096)}" />
           </div>
-          <div class="settings-row settings-row-vertical">
-            <span class="settings-label">提示词（自动检测源语言）
-              <span class="settings-hint">源语言为“自动检测”时使用，可用 {to}</span>
+          <div class="settings-row">
+            <span class="settings-label">提示词预设
+              <span class="settings-hint">风格与行业可组合，选择后覆盖下方自定义提示词</span>
             </span>
-            <textarea class="settings-input settings-textarea" id="llm-auto-prompt" rows="4"
-                    placeholder="${escapeHtml(defaultSettings().llmConfig.autoPrompt)}">${escapeHtml(state.settings.llmConfig.autoPrompt || "")}</textarea>
+            <div class="preset-selects">
+              <select class="settings-input settings-select" id="llm-style-preset" title="翻译风格">
+                ${presetSelectOptions(LLM_STYLE_PRESETS, presetComboCurrent().style, true)}
+              </select>
+              <select class="settings-input settings-select" id="llm-industry-preset" title="行业术语">
+                ${presetSelectOptions(LLM_INDUSTRY_PRESETS, presetComboCurrent().industry, true)}
+              </select>
+            </div>
+          </div>
+          <div class="settings-row">
+            <span class="settings-label" style="flex:0 0 auto">
+              高级选项
+              <span class="settings-hint">自定义提示词</span>
+            </span>
+            <button class="clear-btn" id="llm-advanced-toggle">${llmAdvancedExpanded() ? "收起" : "展开"}</button>
+          </div>
+          <div class="llm-advanced" id="llm-advanced" style="${llmAdvancedExpanded() ? "" : "display:none"}">
+            <div class="settings-row settings-row-vertical">
+              <span class="settings-label">提示词（指定源语言）
+                <span class="settings-hint">可用 {from} / {to} 表示源/目标语言</span>
+              </span>
+              <textarea class="settings-input settings-textarea" id="llm-prompt" rows="4"
+                      placeholder="${escapeHtml(defaultSettings().llmConfig.prompt)}">${escapeHtml(state.settings.llmConfig.prompt || "")}</textarea>
+            </div>
+            <div class="settings-row settings-row-vertical">
+              <span class="settings-label">提示词（自动检测源语言）
+                <span class="settings-hint">源语言为“自动检测”时使用，可用 {to}</span>
+              </span>
+              <textarea class="settings-input settings-textarea" id="llm-auto-prompt" rows="4"
+                      placeholder="${escapeHtml(defaultSettings().llmConfig.autoPrompt)}">${escapeHtml(state.settings.llmConfig.autoPrompt || "")}</textarea>
+            </div>
+          </div>
+        </div>
+        <div class="settings-section">
+          <button class="section-header" id="sec-storage-toggle" type="button">
+            <span class="section-arrow">▸</span> 存储
+          </button>
+          <div class="section-body" id="sec-storage-body" style="display:none">
+            <div class="settings-row">
+              <span class="settings-label">历史记录上限
+                <span class="settings-hint">建议 200，范围 0–2000（0 = 不记录）</span>
+              </span>
+              <input class="settings-input" id="history-limit" type="number" min="0" max="2000"
+                      placeholder="200"
+                      value="${escapeHtml(state.settings.historyLimit ?? 200)}" />
+            </div>
+            <div class="settings-row">
+              <span class="settings-label">翻译缓存上限（条）
+                <span class="settings-hint">建议 200，范围 50–1000</span>
+              </span>
+              <input class="settings-input" id="cache-size" type="number" min="50" max="1000"
+                      placeholder="200"
+                      value="${escapeHtml(state.settings.cacheSize ?? 200)}" />
+            </div>
+            <div class="settings-row">
+              <span class="settings-label">文本翻译历史</span>
+              <div class="history-actions">
+                <button class="clear-btn" id="view-history-btn">查看</button>
+                <button class="clear-btn" id="clear-history-btn">清空</button>
+              </div>
+            </div>
+            <div class="history-list" id="history-list" style="display:none"></div>
+            <div class="settings-row">
+              <span class="settings-label">翻译缓存</span>
+              <button class="clear-btn" id="clear-cache-btn">清空</button>
+            </div>
           </div>
         </div>
       </div>
@@ -384,21 +574,32 @@ function renderMain() {
 
   // Restore input
   const inp = document.querySelector("#text-input");
-  inp.value = state.inputText;
+  const inpR = document.querySelector("#text-input-right");
+
+  updateSides();
 
 // Events
-  inp.addEventListener("input", e => { state.inputText = e.target.value; debouncedTranslate(); });
+  inp.addEventListener("input", e => { state.leftText = e.target.value; state.activeSide = "left"; debouncedTranslate(); });
   inp.addEventListener("keydown", e => {
-    if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); translateText(); }
+    if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); translateText("left"); }
   });
-  inp.addEventListener("paste", () => {
-    setTimeout(() => {
-      state.inputText = inp.value;
-      translateText();
-    }, 0);
+  inp.addEventListener("paste", e => {
+    // 从剪贴板直接取文本，避免与 input 事件处理器的同步清空竞态。
+    const pasted = (e.clipboardData && e.clipboardData.getData("text")) || inp.value;
+    setTimeout(() => handlePaste("left", pasted), 0);
   });
-  document.querySelector("#from-lang").addEventListener("change", e => { state.settings.fromLang = e.target.value; saveSettings().catch(()=>{}); });
-  document.querySelector("#to-lang").addEventListener("change", e => { state.settings.toLang = e.target.value; saveSettings().catch(()=>{}); });
+  inpR.addEventListener("input", e => { state.rightText = e.target.value; state.activeSide = "right"; debouncedTranslate(); });
+  inpR.addEventListener("keydown", e => {
+    if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); translateText("right"); }
+  });
+  inpR.addEventListener("paste", e => {
+    // 从剪贴板直接取文本，避免与 input 事件处理器的同步清空竞态。
+    const pasted = (e.clipboardData && e.clipboardData.getData("text")) || inpR.value;
+    setTimeout(() => handlePaste("right", pasted), 0);
+  });
+  document.querySelector("#from-lang").addEventListener("change", e => { state.settings.fromLang = e.target.value; saveSettings().catch(()=>{}); refreshLangSelects(); updateSides(); });
+  document.querySelector("#to-lang").addEventListener("change", e => { state.settings.toLang = e.target.value; saveSettings().catch(()=>{}); refreshLangSelects(); updateSides(); });
+  document.querySelector("#capture-to-lang").addEventListener("change", e => { state.settings.captureToLang = e.target.value; saveSettings().catch(()=>{}); });
 
   document.querySelector("#settings-btn").addEventListener("click", e => {
     e.stopPropagation();
@@ -422,6 +623,7 @@ function renderMain() {
     saveSettings().catch(() => {});
   });
   document.querySelector("#tts-btn").addEventListener("click", speakInput);
+  document.querySelector("#tts-btn-right").addEventListener("click", speakInput);
 
   document.querySelector("#capture-btn").addEventListener("click", e => { e.stopPropagation(); startCapture(); });
   document.querySelector("#shortcut-row").addEventListener("click", e => { e.stopPropagation(); startHotkeyRecording(); });
@@ -475,55 +677,262 @@ function renderMain() {
   if (baseUrlInput) baseUrlInput.addEventListener("change", e => { state.settings.llmConfig.baseUrl = e.target.value.trim(); saveSettings().catch(() => {}); });
   if (apiKeyInput) apiKeyInput.addEventListener("change", e => { state.settings.llmConfig.apiKey = e.target.value.trim(); saveSettings().catch(() => {}); });
   if (modelInput) modelInput.addEventListener("change", e => { state.settings.llmConfig.model = e.target.value.trim(); saveSettings().catch(() => {}); });
-  if (promptInput) promptInput.addEventListener("change", e => { state.settings.llmConfig.prompt = e.target.value; saveSettings().catch(() => {}); });
-  if (autoPromptInput) autoPromptInput.addEventListener("change", e => { state.settings.llmConfig.autoPrompt = e.target.value; saveSettings().catch(() => {}); });
+  if (promptInput) promptInput.addEventListener("change", e => { state.settings.llmConfig.prompt = e.target.value; syncPresetSelects(); saveSettings().catch(() => {}); });
+  if (autoPromptInput) autoPromptInput.addEventListener("change", e => { state.settings.llmConfig.autoPrompt = e.target.value; syncPresetSelects(); saveSettings().catch(() => {}); });
 
-  inp.focus();
+  // Keep both preset selects in sync when the user edits the prompts.
+  function syncPresetSelects() {
+    const styleSel = document.querySelector("#llm-style-preset");
+    const indSel = document.querySelector("#llm-industry-preset");
+    const combo = presetComboFor(state.settings.llmConfig.prompt, state.settings.llmConfig.autoPrompt);
+    if (styleSel) styleSel.value = combo ? combo.style : PRESET_CUSTOM;
+    if (indSel) indSel.value = combo ? combo.industry : PRESET_CUSTOM;
+  }
+
+  // Presets: style + industry combine into one prompt pair. Changing either
+  // rebuilds the prompts and saves. Selecting "自定义" keeps the textareas.
+  function applyPresetCombo(styleVal, industryVal) {
+    if (styleVal === PRESET_CUSTOM || industryVal === PRESET_CUSTOM) return;
+    const built = buildPresetPrompts(styleVal, industryVal);
+    state.settings.llmConfig.prompt = built.prompt;
+    state.settings.llmConfig.autoPrompt = built.autoPrompt;
+    const p = document.querySelector("#llm-prompt");
+    const a = document.querySelector("#llm-auto-prompt");
+    if (p) p.value = built.prompt;
+    if (a) a.value = built.autoPrompt;
+    saveSettings().catch(() => {});
+  }
+
+  document.querySelector("#llm-style-preset")?.addEventListener("change", e => {
+    const indSel = document.querySelector("#llm-industry-preset");
+    applyPresetCombo(e.target.value, indSel ? indSel.value : PRESET_CUSTOM);
+  });
+  document.querySelector("#llm-industry-preset")?.addEventListener("change", e => {
+    const styleSel = document.querySelector("#llm-style-preset");
+    applyPresetCombo(styleSel ? styleSel.value : PRESET_CUSTOM, e.target.value);
+  });
+
+  // Settings sections: collapse/expand by category.
+  document.querySelectorAll(".section-header").forEach(header => {
+    header.addEventListener("click", e => {
+      e.stopPropagation();
+      const body = header.parentElement.querySelector(":scope > .section-body");
+      if (!body) return;
+      const expanded = body.style.display !== "none";
+      body.style.display = expanded ? "none" : "";
+      header.querySelector(".section-arrow").textContent = expanded ? "▸" : "▾";
+      if (state.settingsOpen) {
+        invoke?.("resize_main_window", { height: settingsHeight() }).catch(() => {});
+      }
+    });
+  });
+
+  // Advanced section toggle (custom prompt editor).
+  document.querySelector("#llm-advanced-toggle")?.addEventListener("click", e => {
+    e.stopPropagation();
+    const box = document.querySelector("#llm-advanced");
+    const btn = e.currentTarget;
+    if (!box) return;
+    const expanded = box.style.display !== "none";
+    box.style.display = expanded ? "none" : "";
+    btn.textContent = expanded ? "展开" : "收起";
+    if (state.settingsOpen) {
+      invoke?.("resize_main_window", { height: settingsHeight() }).catch(() => {});
+    }
+  });
+  const maxTokensInput = document.querySelector("#llm-max-tokens");
+  if (maxTokensInput) maxTokensInput.addEventListener("change", e => {
+    const v = parseInt(e.target.value, 10);
+    state.settings.llmConfig.maxTokens = Number.isFinite(v) && v > 0 ? v : 4096;
+    maxTokensInput.value = state.settings.llmConfig.maxTokens;
+    saveSettings().catch(() => {});
+  });
+
+  // Storage section: limits + clear buttons
+  const historyLimitInput = document.querySelector("#history-limit");
+  if (historyLimitInput) historyLimitInput.addEventListener("change", e => {
+    let v = parseInt(e.target.value, 10);
+    if (!Number.isFinite(v)) v = 200;
+    v = Math.min(2000, Math.max(0, v));
+    state.settings.historyLimit = v;
+    historyLimitInput.value = v;
+    saveSettings().catch(() => {});
+  });
+  const cacheSizeInput = document.querySelector("#cache-size");
+  if (cacheSizeInput) cacheSizeInput.addEventListener("change", e => {
+    let v = parseInt(e.target.value, 10);
+    if (!Number.isFinite(v)) v = 200;
+    v = Math.min(1000, Math.max(50, v));
+    state.settings.cacheSize = v;
+    cacheSizeInput.value = v;
+    saveSettings().catch(() => {});
+  });
+  document.querySelector("#clear-history-btn")?.addEventListener("click", e => {
+    e.stopPropagation();
+    invoke?.("clear_text_history").then(() => {
+      const btn = document.querySelector("#clear-history-btn");
+      if (btn) { btn.textContent = "已清空"; setTimeout(() => { if (btn) btn.textContent = "清空"; }, 1200); }
+      const list = document.querySelector("#history-list");
+      if (list) { list.innerHTML = ""; list.style.display = "none"; }
+      const viewBtn = document.querySelector("#view-history-btn");
+      if (viewBtn) viewBtn.textContent = "查看";
+    }).catch(() => {});
+  });
+  document.querySelector("#view-history-btn")?.addEventListener("click", e => {
+    e.stopPropagation();
+    const btn = e.currentTarget;
+    const list = document.querySelector("#history-list");
+    if (!list) return;
+    if (list.style.display !== "none") {
+      list.style.display = "none";
+      btn.textContent = "查看";
+      return;
+    }
+    invoke?.("list_text_history").then(items => {
+      state.textHistoryCache = items || [];
+      const visible = state.textHistoryCache.slice(0, 20);
+      if (visible.length === 0) {
+        list.innerHTML = `<div class="history-empty">暂无历史记录</div>`;
+      } else {
+        list.innerHTML = visible.map(item => {
+          const time = new Date(item.createdAt).toLocaleString();
+          const lang = `${item.fromLang} → ${item.toLang}`;
+          return `<div class="history-item" data-id="${escapeHtml(item.id)}">
+            <div class="history-text"><span class="history-src">${escapeHtml(item.source)}</span><span class="history-arrow">→</span><span class="history-dst">${escapeHtml(item.translated)}</span></div>
+            <div class="history-meta">${escapeHtml(time)} · ${escapeHtml(lang)} · ${escapeHtml(item.engine)}</div>
+          </div>`;
+        }).join("");
+      }
+      list.style.display = "";
+      btn.textContent = "收起";
+      if (state.settingsOpen) {
+        invoke?.("resize_main_window", { height: settingsHeight() }).catch(() => {});
+      }
+    }).catch(() => {});
+  });
+  // Clicking a history entry restores the source → result pair in the text area.
+  document.querySelector("#history-list")?.addEventListener("click", e => {
+    const itemEl = e.target.closest(".history-item");
+    if (!itemEl) return;
+    const item = state.textHistoryCache.find(x => x.id === itemEl.dataset.id);
+    if (!item) return;
+    state.leftText = item.source;
+    state.rightText = item.translated;
+    state.activeSide = "left";
+    updateSides();
+  });
+  document.querySelector("#clear-cache-btn")?.addEventListener("click", e => {
+    e.stopPropagation();
+    invoke?.("clear_translate_cache").then(count => {
+      const btn = document.querySelector("#clear-cache-btn");
+      if (btn) { btn.textContent = `已清空 ${count} 条`; setTimeout(() => { if (btn) btn.textContent = "清空"; }, 1500); }
+    }).catch(() => {});
+  });
+
+  (state.activeSide === "right" ? inpR : inp).focus();
 }
 
 /* ── Partial DOM updates ── */
 
-function updateOutputArea() {
-  const primaryEl = document.querySelector("#output-primary");
-  const altEl = document.querySelector("#output-alternatives");
-  if (!primaryEl) return;
+// Render both text columns: which side is the current source (read/write),
+// which side shows the result (read-only when the language rules require it),
+// plus the meta rows (detect tag + TTS on the source side, status +
+// alternatives on the result side).
+function updateSides() {
+  const left = document.querySelector("#text-input");
+  const right = document.querySelector("#text-input-right");
+  if (!left || !right) return;
 
-  if (state.textLoading) {
-    primaryEl.innerHTML = `<span class="dot-loading"><span></span><span></span><span></span></span> 翻译中…`;
-    if (altEl) altEl.innerHTML = "";
-  } else if (state.translatedText) {
-    primaryEl.textContent = state.translatedText;
-    if (altEl && state.alternatives.length > 0) {
-      altEl.innerHTML = state.alternatives
-        .map(a => `<span class="alt-tag">${escapeHtml(a)}</span>`)
-        .join("");
-    } else if (altEl) {
-      altEl.innerHTML = "";
+  left.value = state.leftText;
+  right.value = state.rightText;
+
+  const fromLang = state.settings?.fromLang || "auto";
+  const toLang = state.settings?.toLang || "zh-CHS";
+  // 目标语言为“自动检测”时无法从左→右翻译；源语言为“自动检测”时无法从右→左翻译。
+  const leftLocked = toLang === "auto";
+  const rightLocked = fromLang === "auto";
+
+  left.readOnly = leftLocked;
+  right.readOnly = rightLocked;
+  left.placeholder = leftLocked ? "目标语言为“自动检测”，不能在此输入" : "输入要翻译的文本…";
+  right.placeholder = rightLocked ? "源语言为“自动检测”，不能在此输入" : "输入要翻译的文本…";
+
+  let sourceSide = state.activeSide;
+  if (rightLocked) sourceSide = "left";
+  if (leftLocked) sourceSide = "right";
+  const outputSide = sourceSide === "left" ? "right" : "left";
+
+  // Detect tag follows the source side.
+  const detectL = document.querySelector("#detected-lang");
+  const detectR = document.querySelector("#detected-lang-right");
+  for (const el of [detectL, detectR]) if (el) el.style.display = "none";
+  if (state.detectedLang) {
+    const label = LANGUAGES.find(l => l.value === state.detectedLang)?.label || state.detectedLang;
+    const el = sourceSide === "left" ? detectL : detectR;
+    if (el) {
+      el.textContent = `检测: ${label}`;
+      el.style.display = "";
     }
-  } else if (state.loading && state.status) {
-    primaryEl.textContent = state.status;
-    if (altEl) altEl.innerHTML = "";
-  } else if (state.status) {
-    primaryEl.textContent = state.status;
-    if (altEl) altEl.innerHTML = "";
-  } else {
-    primaryEl.textContent = "";
-    if (altEl) altEl.innerHTML = "";
   }
+
+  // TTS button follows the source side.
+  const ttsL = document.querySelector("#tts-btn");
+  const ttsR = document.querySelector("#tts-btn-right");
+  for (const el of [ttsL, ttsR]) if (el) el.style.display = "none";
+  const tts = sourceSide === "left" ? ttsL : ttsR;
+  if (tts) {
+    tts.style.display = "";
+    tts.classList.toggle("speaking", state.ttsPlaying);
+  }
+
+  // Status + alternatives live on the result side.
+  updateOutputMeta("#status-left", "#alternatives-left", outputSide === "left");
+  updateOutputMeta("#status-right", "#alternatives-right", outputSide === "right");
 
   const btn = document.querySelector("#capture-btn");
   if (btn) btn.disabled = state.loading;
 }
 
-function updateDetectedLang() {
-  const el = document.querySelector("#detected-lang");
-  if (!el) return;
-  if (state.detectedLang) {
-    const label = LANGUAGES.find(l => l.value === state.detectedLang)?.label || state.detectedLang;
-    el.textContent = `检测: ${label}`;
-    el.style.display = "";
+function updateOutputMeta(statusSel, altSel, visible) {
+  const statusEl = document.querySelector(statusSel);
+  const altEl = document.querySelector(altSel);
+  if (!statusEl || !altEl) return;
+
+  if (!visible) {
+    statusEl.innerHTML = "";
+    statusEl.style.display = "none";
+    altEl.innerHTML = "";
+    altEl.style.display = "none";
+    return;
+  }
+
+  if (state.textLoading) {
+    statusEl.style.display = "";
+    statusEl.innerHTML = `<span class="dot-loading"><span></span><span></span><span></span></span> 翻译中…`;
+    altEl.style.display = "none";
+    altEl.innerHTML = "";
+  } else if (state.status && state.statusType === "error") {
+    statusEl.style.display = "";
+    statusEl.textContent = state.status;
+    statusEl.classList.add("error");
+    altEl.style.display = "none";
+    altEl.innerHTML = "";
+  } else if (state.loading && state.status) {
+    statusEl.style.display = "";
+    statusEl.textContent = state.status;
+    statusEl.classList.remove("error");
+    altEl.style.display = "none";
+    altEl.innerHTML = "";
   } else {
-    el.style.display = "none";
+    statusEl.innerHTML = "";
+    statusEl.style.display = "none";
+    if (state.alternatives.length > 0) {
+      altEl.style.display = "";
+      altEl.innerHTML = state.alternatives.map(a => `<span class="alt-tag">${escapeHtml(a)}</span>`).join("");
+    } else {
+      altEl.style.display = "none";
+      altEl.innerHTML = "";
+    }
   }
 }
 
@@ -543,22 +952,29 @@ async function startCapture() {
     state.loading = false;
     state.status = String(err);
     state.statusType = "error";
-    updateOutputArea();
+    updateSides();
   }
 }
 
-async function translateText() {
-  const text = state.inputText.trim();
+async function translateText(side) {
+  const isLeft = side !== "right";
+  const text = (isLeft ? state.leftText : state.rightText).trim();
   if (!text) return;
+
+  // 反向翻译（右侧输入）：源/目标语言互换。
+  const fromLang = isLeft ? state.settings.fromLang : state.settings.toLang;
+  const toLang = isLeft ? state.settings.toLang : state.settings.fromLang;
+  if (toLang === "auto") return;
 
   // Claim this as the latest request; older in-flight ones become stale.
   const seq = ++translateSeq;
 
   state.textLoading = true;
-  state.translatedText = "";
+  state.status = "";
+  state.statusType = "";
   state.alternatives = [];
   state.detectedLang = "";
-  updateOutputArea();
+  updateSides();
 
   // Validate LLM config
   if (state.settings.textTranslateEngine === "llm" && !state.settings.llmConfig.apiKey) {
@@ -566,18 +982,18 @@ async function translateText() {
       state.textLoading = false;
       state.status = "请先在设置中配置 API Key";
       state.statusType = "error";
-      updateOutputArea();
+      updateSides();
     }
     return;
   }
 
   try {
-    const r = await invoke("translate_text", { text, fromLang: state.settings.fromLang, toLang: state.settings.toLang });
+    const r = await invoke("translate_text", { text, fromLang, toLang });
     if (seq !== translateSeq) return; // superseded by a newer request
-    state.translatedText = r.translatedText;
+    if (isLeft) state.rightText = r.translatedText;
+    else state.leftText = r.translatedText;
     state.alternatives = r.alternatives || [];
     state.detectedLang = r.fromLangDetected;
-    updateDetectedLang();
   } catch (err) {
     if (seq !== translateSeq) return; // superseded; ignore stale error
     state.status = String(err);
@@ -586,32 +1002,31 @@ async function translateText() {
     // Only the latest request controls the loading state / final render.
     if (seq === translateSeq) {
       state.textLoading = false;
-      updateOutputArea();
+      updateSides();
     }
   }
 }
 
 function speakInput() {
-  const text = state.inputText.trim();
+  const isLeft = state.activeSide !== "right";
+  const text = (isLeft ? state.leftText : state.rightText).trim();
   if (!text) return;
 
   if (window.speechSynthesis.speaking) {
     window.speechSynthesis.cancel();
     state.ttsPlaying = false;
-    const btn = document.querySelector("#tts-btn");
-    if (btn) btn.classList.remove("speaking");
+    updateSides();
     return;
   }
 
   const utt = new SpeechSynthesisUtterance(text);
-  const fromLang = state.detectedLang || state.settings.fromLang;
+  const fromLang = state.detectedLang || (isLeft ? state.settings.fromLang : state.settings.toLang);
   utt.lang = TTS_LANG_MAP[fromLang] || fromLang;
-  utt.onend = () => { state.ttsPlaying = false; const b = document.querySelector("#tts-btn"); if (b) b.classList.remove("speaking"); };
+  utt.onend = () => { state.ttsPlaying = false; updateSides(); };
   utt.onerror = utt.onend;
 
   state.ttsPlaying = true;
-  const btn = document.querySelector("#tts-btn");
-  if (btn) btn.classList.add("speaking");
+  updateSides();
   window.speechSynthesis.speak(utt);
 }
 
@@ -795,6 +1210,11 @@ async function boot() {
   if (mode.startsWith("overlay")) { await renderOverlay(); return; }
   try {
     await loadSettings();
+    // 两边不能同时为“自动检测”（反向翻译时目标语言需明确）。
+    if (state.settings.fromLang === "auto" && state.settings.toLang === "auto") {
+      state.settings.toLang = "zh-CHS";
+      saveSettings().catch(() => {});
+    }
   } catch (err) {
     console.error("load_settings failed, falling back to defaults", err);
     state.settings = defaultSettings();

--- a/ui/app.js
+++ b/ui/app.js
@@ -160,23 +160,61 @@ let debounceTimer = null;
 // and re-translate at any time — even mid-translation.
 let translateSeq = 0;
 
-function debouncedTranslate() {
+function clearTranslationTimer() {
   if (debounceTimer) clearTimeout(debounceTimer);
+  debounceTimer = null;
+}
+
+function invalidateTranslation() {
+  clearTranslationTimer();
+  translateSeq++;
+}
+
+function translationContextKey(side) {
+  const isLeft = side !== "right";
+  const settings = state.settings || defaultSettings();
+  return JSON.stringify({
+    side: isLeft ? "left" : "right",
+    text: (isLeft ? state.leftText : state.rightText).trim(),
+    fromLang: isLeft ? settings.fromLang : settings.toLang,
+    toLang: isLeft ? settings.toLang : settings.fromLang,
+    engine: settings.textTranslateEngine,
+    proxyMode: settings.proxyMode,
+    customProxy: settings.customProxy,
+    llmConfig: settings.textTranslateEngine === "llm" ? settings.llmConfig : null
+  });
+}
+
+function isCurrentTranslation(seq, side, contextKey) {
+  return seq === translateSeq &&
+    state.activeSide === side &&
+    translationContextKey(side) === contextKey;
+}
+
+function translationSettingsChanged() {
+  invalidateTranslation();
+  state.textLoading = false;
+  updateSides();
+}
+
+function debouncedTranslate(side) {
+  invalidateTranslation();
+  const scheduledSeq = translateSeq;
+  const source = side === "right" ? state.rightText : state.leftText;
+  const text = (source || "").trim();
+  if (!text) {
+    state.textLoading = false;
+    state.alternatives = [];
+    state.detectedLang = "";
+    if (side === "right") state.leftText = "";
+    else state.rightText = "";
+    updateSides();
+    return;
+  }
+
   debounceTimer = setTimeout(() => {
-    const source = state.activeSide === "right" ? state.rightText : state.leftText;
-    const text = (source || "").trim();
-    if (text) {
-      translateText(state.activeSide === "right" ? "right" : "left");
-    } else {
-      // Source cleared: cancel any in-flight result and reset the output side.
-      translateSeq++;
-      state.textLoading = false;
-      state.alternatives = [];
-      state.detectedLang = "";
-      if (state.activeSide === "right") state.leftText = "";
-      else state.rightText = "";
-      updateSides();
-    }
+    debounceTimer = null;
+    if (scheduledSeq === translateSeq) translateText(side);
   }, 500);
 }
 
@@ -257,16 +295,16 @@ function escapeHtml(v) {
 // 方向规则：左侧输入 → 左侧为源，右侧输出 {toLang} 译文；
 //           右侧输入 → 右侧为源，左侧输出 {fromLang} 译文。
 // 语言错配/混合文本由 LLM 提示词硬规则兜底，不再做前端方向纠正。
-function handlePaste(side, value) {
-  if (!value) return; // 空值不处理，避免覆盖已有文本
-  if (side === "left") {
-    state.leftText = value;
-    state.activeSide = "left";
-  } else {
-    state.rightText = value;
-    state.activeSide = "right";
-  }
-  translateText(side);
+function handlePaste(side, input) {
+  // Run after the browser's default paste so we read the complete textarea
+  // value, including text before/after the insertion point.
+  setTimeout(() => {
+    const value = input.value;
+    if (side === "left") state.leftText = value;
+    else state.rightText = value;
+    state.activeSide = side;
+    translateText(side);
+  }, 0);
 }
 
 function delay(ms) { return new Promise(r => setTimeout(r, ms)); }
@@ -579,26 +617,22 @@ function renderMain() {
   updateSides();
 
 // Events
-  inp.addEventListener("input", e => { state.leftText = e.target.value; state.activeSide = "left"; debouncedTranslate(); });
+  inp.addEventListener("input", e => { state.leftText = e.target.value; state.activeSide = "left"; debouncedTranslate("left"); });
   inp.addEventListener("keydown", e => {
     if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); translateText("left"); }
   });
   inp.addEventListener("paste", e => {
-    // 从剪贴板直接取文本，避免与 input 事件处理器的同步清空竞态。
-    const pasted = (e.clipboardData && e.clipboardData.getData("text")) || inp.value;
-    setTimeout(() => handlePaste("left", pasted), 0);
+    handlePaste("left", inp);
   });
-  inpR.addEventListener("input", e => { state.rightText = e.target.value; state.activeSide = "right"; debouncedTranslate(); });
+  inpR.addEventListener("input", e => { state.rightText = e.target.value; state.activeSide = "right"; debouncedTranslate("right"); });
   inpR.addEventListener("keydown", e => {
     if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); translateText("right"); }
   });
   inpR.addEventListener("paste", e => {
-    // 从剪贴板直接取文本，避免与 input 事件处理器的同步清空竞态。
-    const pasted = (e.clipboardData && e.clipboardData.getData("text")) || inpR.value;
-    setTimeout(() => handlePaste("right", pasted), 0);
+    handlePaste("right", inpR);
   });
-  document.querySelector("#from-lang").addEventListener("change", e => { state.settings.fromLang = e.target.value; saveSettings().catch(()=>{}); refreshLangSelects(); updateSides(); });
-  document.querySelector("#to-lang").addEventListener("change", e => { state.settings.toLang = e.target.value; saveSettings().catch(()=>{}); refreshLangSelects(); updateSides(); });
+  document.querySelector("#from-lang").addEventListener("change", e => { state.settings.fromLang = e.target.value; translationSettingsChanged(); saveSettings().catch(()=>{}); refreshLangSelects(); });
+  document.querySelector("#to-lang").addEventListener("change", e => { state.settings.toLang = e.target.value; translationSettingsChanged(); saveSettings().catch(()=>{}); refreshLangSelects(); });
   document.querySelector("#capture-to-lang").addEventListener("change", e => { state.settings.captureToLang = e.target.value; saveSettings().catch(()=>{}); });
 
   document.querySelector("#settings-btn").addEventListener("click", e => {
@@ -636,6 +670,7 @@ function renderMain() {
       e.stopPropagation();
       const newEngine = e.currentTarget.dataset.engine;
       state.settings.textTranslateEngine = newEngine;
+      translationSettingsChanged();
       saveSettings().catch(() => {});
       // Update active state
       document.querySelectorAll("#engine-switcher .engine-btn").forEach(b => b.classList.toggle("active", b.dataset.engine === newEngine));
@@ -656,6 +691,7 @@ function renderMain() {
       e.stopPropagation();
       const newMode = e.currentTarget.dataset.proxy;
       state.settings.proxyMode = newMode;
+      translationSettingsChanged();
       saveSettings().catch(() => {});
       document.querySelectorAll("#proxy-switcher .engine-btn").forEach(b => b.classList.toggle("active", b.dataset.proxy === newMode));
       const customRow = document.querySelector("#custom-proxy-row");
@@ -666,7 +702,7 @@ function renderMain() {
     });
   });
   const customProxyInput = document.querySelector("#custom-proxy");
-  if (customProxyInput) customProxyInput.addEventListener("change", e => { state.settings.customProxy = e.target.value.trim(); saveSettings().catch(() => {}); });
+  if (customProxyInput) customProxyInput.addEventListener("change", e => { state.settings.customProxy = e.target.value.trim(); translationSettingsChanged(); saveSettings().catch(() => {}); });
 
   // LLM config inputs
   const baseUrlInput = document.querySelector("#llm-base-url");
@@ -674,11 +710,11 @@ function renderMain() {
   const modelInput = document.querySelector("#llm-model");
   const promptInput = document.querySelector("#llm-prompt");
   const autoPromptInput = document.querySelector("#llm-auto-prompt");
-  if (baseUrlInput) baseUrlInput.addEventListener("change", e => { state.settings.llmConfig.baseUrl = e.target.value.trim(); saveSettings().catch(() => {}); });
-  if (apiKeyInput) apiKeyInput.addEventListener("change", e => { state.settings.llmConfig.apiKey = e.target.value.trim(); saveSettings().catch(() => {}); });
-  if (modelInput) modelInput.addEventListener("change", e => { state.settings.llmConfig.model = e.target.value.trim(); saveSettings().catch(() => {}); });
-  if (promptInput) promptInput.addEventListener("change", e => { state.settings.llmConfig.prompt = e.target.value; syncPresetSelects(); saveSettings().catch(() => {}); });
-  if (autoPromptInput) autoPromptInput.addEventListener("change", e => { state.settings.llmConfig.autoPrompt = e.target.value; syncPresetSelects(); saveSettings().catch(() => {}); });
+  if (baseUrlInput) baseUrlInput.addEventListener("change", e => { state.settings.llmConfig.baseUrl = e.target.value.trim(); translationSettingsChanged(); saveSettings().catch(() => {}); });
+  if (apiKeyInput) apiKeyInput.addEventListener("change", e => { state.settings.llmConfig.apiKey = e.target.value.trim(); translationSettingsChanged(); saveSettings().catch(() => {}); });
+  if (modelInput) modelInput.addEventListener("change", e => { state.settings.llmConfig.model = e.target.value.trim(); translationSettingsChanged(); saveSettings().catch(() => {}); });
+  if (promptInput) promptInput.addEventListener("change", e => { state.settings.llmConfig.prompt = e.target.value; syncPresetSelects(); translationSettingsChanged(); saveSettings().catch(() => {}); });
+  if (autoPromptInput) autoPromptInput.addEventListener("change", e => { state.settings.llmConfig.autoPrompt = e.target.value; syncPresetSelects(); translationSettingsChanged(); saveSettings().catch(() => {}); });
 
   // Keep both preset selects in sync when the user edits the prompts.
   function syncPresetSelects() {
@@ -700,6 +736,7 @@ function renderMain() {
     const a = document.querySelector("#llm-auto-prompt");
     if (p) p.value = built.prompt;
     if (a) a.value = built.autoPrompt;
+    translationSettingsChanged();
     saveSettings().catch(() => {});
   }
 
@@ -745,6 +782,7 @@ function renderMain() {
     const v = parseInt(e.target.value, 10);
     state.settings.llmConfig.maxTokens = Number.isFinite(v) && v > 0 ? v : 4096;
     maxTokensInput.value = state.settings.llmConfig.maxTokens;
+    translationSettingsChanged();
     saveSettings().catch(() => {});
   });
 
@@ -816,9 +854,17 @@ function renderMain() {
     if (!itemEl) return;
     const item = state.textHistoryCache.find(x => x.id === itemEl.dataset.id);
     if (!item) return;
-    state.leftText = item.source;
-    state.rightText = item.translated;
-    state.activeSide = "left";
+    invalidateTranslation();
+    state.textLoading = false;
+    if (item.sourceSide === "right") {
+      state.leftText = item.translated;
+      state.rightText = item.source;
+      state.activeSide = "right";
+    } else {
+      state.leftText = item.source;
+      state.rightText = item.translated;
+      state.activeSide = "left";
+    }
     updateSides();
   });
   document.querySelector("#clear-cache-btn")?.addEventListener("click", e => {
@@ -957,17 +1003,29 @@ async function startCapture() {
 }
 
 async function translateText(side) {
+  side = side === "right" ? "right" : "left";
+  // Manual triggers (Enter/paste) must supersede any pending debounce, while
+  // every new request immediately invalidates all older in-flight requests.
+  invalidateTranslation();
   const isLeft = side !== "right";
   const text = (isLeft ? state.leftText : state.rightText).trim();
-  if (!text) return;
+  if (!text) {
+    state.textLoading = false;
+    updateSides();
+    return;
+  }
 
   // 反向翻译（右侧输入）：源/目标语言互换。
   const fromLang = isLeft ? state.settings.fromLang : state.settings.toLang;
   const toLang = isLeft ? state.settings.toLang : state.settings.fromLang;
-  if (toLang === "auto") return;
+  if (toLang === "auto") {
+    state.textLoading = false;
+    updateSides();
+    return;
+  }
 
-  // Claim this as the latest request; older in-flight ones become stale.
-  const seq = ++translateSeq;
+  const seq = translateSeq;
+  const contextKey = translationContextKey(side);
 
   state.textLoading = true;
   state.status = "";
@@ -978,7 +1036,7 @@ async function translateText(side) {
 
   // Validate LLM config
   if (state.settings.textTranslateEngine === "llm" && !state.settings.llmConfig.apiKey) {
-    if (seq === translateSeq) {
+    if (isCurrentTranslation(seq, side, contextKey)) {
       state.textLoading = false;
       state.status = "请先在设置中配置 API Key";
       state.statusType = "error";
@@ -988,19 +1046,19 @@ async function translateText(side) {
   }
 
   try {
-    const r = await invoke("translate_text", { text, fromLang, toLang });
-    if (seq !== translateSeq) return; // superseded by a newer request
+    const r = await invoke("translate_text", { text, fromLang, toLang, sourceSide: side });
+    if (!isCurrentTranslation(seq, side, contextKey)) return;
     if (isLeft) state.rightText = r.translatedText;
     else state.leftText = r.translatedText;
     state.alternatives = r.alternatives || [];
     state.detectedLang = r.fromLangDetected;
   } catch (err) {
-    if (seq !== translateSeq) return; // superseded; ignore stale error
+    if (!isCurrentTranslation(seq, side, contextKey)) return;
     state.status = String(err);
     state.statusType = "error";
   } finally {
     // Only the latest request controls the loading state / final render.
-    if (seq === translateSeq) {
+    if (isCurrentTranslation(seq, side, contextKey)) {
       state.textLoading = false;
       updateSides();
     }

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -182,6 +182,33 @@ body.capture-preparing *::after {
   flex-direction: column;
   gap: 12px;
 }
+.section-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-main);
+  padding: 2px 0;
+  text-align: left;
+  user-select: none;
+}
+.section-header:hover {
+  color: var(--accent);
+}
+.section-arrow {
+  color: var(--text-sub);
+  font-size: 11px;
+  transition: transform 0.15s;
+}
+.section-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
 .settings-row {
   display: flex;
   justify-content: space-between;
@@ -264,6 +291,7 @@ body.capture-preparing *::after {
   overflow-y: auto;
 }
 .input-area::placeholder { color: #D4D4D8; }
+.input-area[readonly] { cursor: default; opacity: 0.85; }
 .meta-info {
   display: flex;
   justify-content: space-between;
@@ -468,6 +496,126 @@ body.capture-preparing *::after {
 
 #llm-settings {
   margin-top: 8px;
+}
+
+.llm-advanced {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.settings-select {
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--bg-app);
+  border: 1px solid #E4E4E7;
+  border-radius: var(--radius-sm);
+  padding: 4px 8px;
+  font-size: 12px;
+  color: var(--text-main);
+  flex: 1 1 auto;
+  min-width: 0;
+  margin-left: 12px;
+  outline: none;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+.settings-select:focus {
+  border-color: var(--accent);
+}
+
+.preset-selects {
+  display: flex;
+  gap: 6px;
+  flex: 1 1 auto;
+  min-width: 0;
+  margin-left: 12px;
+}
+.preset-selects .settings-select {
+  flex: 1 1 0;
+  margin-left: 0;
+  min-width: 0;
+}
+
+.clear-btn {
+  background: var(--bg-app);
+  border: 1px solid #E4E4E7;
+  border-radius: var(--radius-sm);
+  padding: 4px 12px;
+  font-size: 12px;
+  color: var(--text-main);
+  cursor: pointer;
+  flex: 0 0 auto;
+  transition: all 0.15s;
+}
+.clear-btn:hover {
+  border-color: #f44336;
+  color: #f44336;
+}
+
+.history-actions {
+  display: flex;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.history-item {
+  background: var(--bg-app);
+  border: 1px solid #F0F0F2;
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+.history-item:hover {
+  border-color: var(--accent);
+}
+
+.history-text {
+  display: flex;
+  gap: 8px;
+  font-size: 12px;
+  line-height: 1.5;
+  align-items: baseline;
+}
+.history-src {
+  color: var(--text-sub);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 45%;
+  flex: 0 0 auto;
+}
+.history-arrow {
+  color: #A1A1AA;
+  flex: 0 0 auto;
+}
+.history-dst {
+  color: var(--text-main);
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+.history-meta {
+  font-size: 11px;
+  color: #A1A1AA;
+  margin-top: 2px;
+}
+.history-empty {
+  font-size: 12px;
+  color: var(--text-sub);
+  text-align: center;
+  padding: 8px 0;
 }
 
 /* ── Status ── */


### PR DESCRIPTION
## 概述 / Overview

双向文本翻译输入、持久化翻译缓存、文本翻译历史、截图翻译独立目标语言,以及 LLM 引擎的稳健性与安全加固。

Bidirectional text translation input, persisted translation cache, text history, capture-specific target language, plus LLM engine robustness and security hardening.

## 功能 / Features

1. **双向翻译输入 / Bidirectional text input**
   - 左右两侧均为输入框:左侧输入按 `from → to` 翻译,右侧输入按 `to → from` 反向翻译
   - Both panes are editable: left input translates `from → to`, right input translates `to → from`
   - "自动检测"互斥规则:目标为 auto 时左侧锁定,源为 auto 时右侧锁定
   - Mutual-exclusion rules for auto-detect: source/target lock rules
   - 检测标签与朗读按钮跟随当前源侧
   - Detection tag and TTS button follow the active source side

2. **持久化翻译缓存 / Persisted translation cache**
   - 精确整句匹配(文本+语言+引擎+模型),LRU 上限可配(默认 200),跨重启保留
   - Exact-match LRU cache keyed by text/languages/engine/model, configurable cap, persists across restarts
   - 修复缓存污染:结果与原文相同的条目不写入、命中时自动剔除
   - Poisoned-entry guard: identity results are never cached and stale ones are dropped on read

3. **文本翻译历史 / Text translation history**
   - 翻译成功自动写入,上限可配(默认 200),设置面板可查看最近 20 条、点击还原、一键清空
   - Auto-saved on success, configurable cap, view/restore/clear in settings

4. **截图翻译独立目标语言 / Capture-specific target language**
   - 头部新增截图目标语言选择器,截图翻译源语言固定为自动检测(修复设置 zh-CHS 时截英文图不翻译的问题)
   - Header selector for capture target language; capture source is always auto-detect (fixes no-op when fromLang was fixed to zh-CHS)

5. **LLM 稳健性与安全 / LLM robustness & security**
   - 所有 HTTP 客户端增加连接/请求超时;LLM 整体 60s 超时
   - Timeouts on all HTTP clients; 60s overall LLM timeout
   - 瞬态错误(超时/5xx/429)指数退避重试 2 次,失败自动降级到免费备用引擎(永不降级到 LLM),结果区提示
   - Retry with backoff on transient errors, fallback to a free engine (never to LLM), with an in-UI notice
   - Windows DPAPI 加密 API Key 落盘,明文自动迁移;`secure.rs`
   - DPAPI-encrypted API key at rest with plaintext auto-migration
   - 追加系统级硬规则提示词:无论输入语言如何,始终输出目标语言译文,禁止解释/聊天式回答
   - Appended hard-rule system prompt: always output target-language text, no chatty replies
   - LLM `max_tokens` 可配,输出截断时提示;auto 模式本地语言检测(修复检测标签与 TTS 语言失真)
   - Configurable `max_tokens` with truncation notice; local language detection for auto mode
   - 生产环境滚动日志文件(按天)
   - Rolling daily log files in the app data dir

## 测试 / Testing

- Windows x64 实测:双向翻译、粘贴竞态修复(剪贴板直读)、缓存命中/污染修复、截图翻译目标语言、DPAPI 密钥迁移
- Tested on Windows x64: bidirectional input, paste race fix, cache poison fix, capture target language, DPAPI key migration
- 语言错配/混合文本经 DeepSeek 实测四场景(纯中/纯英/混合×双向)均输出正确目标语言
- Four mixed/pure language scenarios verified against DeepSeek
- 注:macOS/Linux 未在本机验证;非 Windows 平台密钥加密退化为明文存储
- Note: macOS/Linux untested locally; key encryption falls back to plaintext off-Windows

## 提交 / Commits

- `feat: bidirectional text translation input`
- `feat: persisted translation cache, text history and capture target language`
- `feat: LLM robustness and security hardening`
