### PR TITLE
fix: 输入法组合阶段不再抢翻拼音，回车归还给候选词

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -1,4 +1,5 @@
 import { focusTextInputIfAllowed } from "./focus-helpers.mjs";
+import { shouldTranslateOnInput, shouldTranslateOnEnter } from "./ime-guards.mjs";
 
 const LANGUAGES = [
   { value: "auto", label: "自动检测" },
@@ -387,9 +388,29 @@ function renderMain() {
   inp.value = state.inputText;
 
 // Events
-  inp.addEventListener("input", e => { state.inputText = e.target.value; debouncedTranslate(); });
+  // Tracked IME state: `input` events keep firing while the user is still
+  // picking candidates, so the events alone are not enough to know when text
+  // has actually been committed. See ./ime-guards.mjs.
+  let composing = false;
+  inp.addEventListener("compositionstart", () => { composing = true; });
+  inp.addEventListener("compositionend", () => {
+    composing = false;
+    state.inputText = inp.value;
+    debouncedTranslate();
+  });
+  inp.addEventListener("input", e => {
+    state.inputText = e.target.value;
+    // Translate committed text only — never the raw pinyin/kana buffer.
+    if (!shouldTranslateOnInput(e, composing)) return;
+    debouncedTranslate();
+  });
   inp.addEventListener("keydown", e => {
-    if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); translateText(); }
+    // While the IME owns the keystroke, Enter belongs to the composition: let it
+    // through untouched so the candidate is committed instead of being eaten by
+    // preventDefault() (which also translated the unfinished buffer).
+    if (!shouldTranslateOnEnter(e, composing)) return;
+    e.preventDefault();
+    translateText();
   });
   inp.addEventListener("paste", () => {
     setTimeout(() => {

--- a/ui/ime-guards.mjs
+++ b/ui/ime-guards.mjs
@@ -1,0 +1,38 @@
+// IME composition guards for the text translation input.
+//
+// While an IME composition is active the textarea does not hold the text the
+// user means: it holds the raw buffer ("nihao" / "apple"), which is still
+// underlined and can be replaced by the candidate list. Chromium / WebView2
+// nevertheless fires `input` events during the composition, so a plain
+// "translate on input" debounce ends up translating the unfinished buffer.
+//
+// The Enter keystroke is worse: the key used to confirm a candidate reaches the
+// page as a normal `keydown` with `isComposing === true` (or `keyCode === 229`
+// on engines that do not expose the flag). Calling preventDefault() on it both
+// swallows the IME commit and fires a translation of the raw buffer, so
+// Chinese / Japanese / Korean — and Microsoft Pinyin's own English mode — users
+// have to press Enter one extra time before they see a sane result.
+//
+// Both cases are ignored here so that typing commits normally and the
+// translation always runs on committed text only.
+
+export function isImeComposing(event, composing) {
+  if (composing) return true;
+  if (!event) return false;
+  if (event.isComposing) return true;
+  // Legacy / engine fallback for "this keystroke belongs to the IME".
+  return event.keyCode === 229;
+}
+
+// Only schedule the debounced auto-translate for `input` events that carry
+// committed text, never for the raw composition buffer.
+export function shouldTranslateOnInput(event, composing) {
+  return !isImeComposing(event, composing);
+}
+
+// Enter translates only when the keystroke is not the IME's "confirm
+// candidate". Shift+Enter keeps inserting a newline as before.
+export function shouldTranslateOnEnter(event, composing) {
+  if (!event || isImeComposing(event, composing)) return false;
+  return event.key === "Enter" && !event.shiftKey;
+}

--- a/ui/ime-guards.test.mjs
+++ b/ui/ime-guards.test.mjs
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isImeComposing,
+  shouldTranslateOnInput,
+  shouldTranslateOnEnter,
+} from "./ime-guards.mjs";
+
+test("组合输入中的 input 事件不触发翻译", () => {
+  // Chromium: the composition buffer arrives with isComposing === true.
+  assert.equal(shouldTranslateOnInput({ isComposing: true }, false), false);
+  // Engines without the flag fall back to keyCode 229.
+  assert.equal(shouldTranslateOnInput({ keyCode: 229 }, false), false);
+  // compositionstart already seen: trust the tracked state.
+  assert.equal(shouldTranslateOnInput({ isComposing: false }, true), false);
+});
+
+test("已上屏文本的 input 事件照常触发翻译", () => {
+  assert.equal(shouldTranslateOnInput({ isComposing: false, keyCode: 0 }, false), true);
+  assert.equal(shouldTranslateOnInput({ data: "你好" }, false), true);
+});
+
+test("组合输入期间的回车交给输入法确认候选词，不当作翻译指令", () => {
+  assert.equal(shouldTranslateOnEnter({ key: "Enter", isComposing: true }, false), false);
+  assert.equal(shouldTranslateOnEnter({ key: "Enter", keyCode: 229 }, false), false);
+  assert.equal(shouldTranslateOnEnter({ key: "Enter" }, true), false);
+});
+
+test("非组合状态下的回车触发翻译，Shift+Enter 仍然换行", () => {
+  assert.equal(shouldTranslateOnEnter({ key: "Enter", isComposing: false }, false), true);
+  assert.equal(shouldTranslateOnEnter({ key: "Enter", shiftKey: true }, false), false);
+  assert.equal(shouldTranslateOnEnter({ key: "a" }, false), false);
+});
+
+test("isImeComposing 兼容事件标记与旧版 keyCode", () => {
+  assert.equal(isImeComposing(undefined, false), false);
+  assert.equal(isImeComposing({}, false), false);
+  assert.equal(isImeComposing({ isComposing: true }, false), true);
+  assert.equal(isImeComposing({ keyCode: 229 }, false), true);
+  assert.equal(isImeComposing({}, true), true);
+});


### PR DESCRIPTION
接着 #17 那个问题，改动都在 `ui/`，Rust 侧没碰。

主窗口输入框原来有两处没管输入法的组合状态：

1. `input` 在候选词上屏前也在触发（`isComposing=true`），500ms 防抖于是把还没上屏的 `nihao` / `konnichiha` 当正文送去翻译，用户看到的就是乱码结果；
2. 回车那条没判断 `isComposing` 就 `preventDefault()`，把用户确认候选词的那次回车吞掉了，顺带又翻了一次未完成的串。

所以中文、日文、韩文，还有微软拼音的英文模式，都得额外按一次回车才拿得到正确译文。

这个 PR 把判断规则挪进 `ui/ime-guards.mjs`（跟现有的 `focus-helpers.mjs` 一个路子），app.js 里只多两个调用：

- `compositionstart` / `compositionend` 记一下组合状态；
- 组合期间的 `input` 只更新 `state.inputText`，不排程翻译；
- `compositionend`（文本真正上屏）之后再排程防抖翻译；
- 回车只在不是输入法确认键的时候才 `preventDefault()` + 立即翻译。

`isComposing` 之外还兜了一层 `keyCode === 229`，怕有的内核不给标记。英文直输、粘贴、Enter 立刻翻译、Shift+Enter 换行这些行为都没改。

验证：

```
node --test ui/ime-guards.test.mjs ui/focus-helpers.test.mjs   # 10 pass
```

另外在 Windows 上用 `cargo tauri build` 出了包，挂在跑着的 0.2.29 上对比过：打 `nihao` 不选词时，原版会把拼音发去翻译并且吃掉回车，改完的组合期一次翻译都不发、回车交给输入法正常上屏，上屏后翻「你好」。
