### PR TITLE
feat: 切换语言或引擎后立即重翻，不用再按一次回车

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -1,5 +1,6 @@
 import { focusTextInputIfAllowed } from "./focus-helpers.mjs";
 import { shouldTranslateOnInput, shouldTranslateOnEnter } from "./ime-guards.mjs";
+import { canRetranslateNow } from "./retranslate.mjs";
 
 const LANGUAGES = [
   { value: "auto", label: "自动检测" },
@@ -127,6 +128,25 @@ function debouncedTranslate() {
   }, 500);
 }
 
+// Changing a language or engine select leaves the *previous* result on screen,
+// which used to mean one more Enter press to see the new one. Re-run the
+// translation on the change instead. `awaitPersisted` matters for the engine:
+// translate_text gets the languages as arguments, but the engine itself is read
+// from the saved settings by the Rust side, so the write has to land first.
+async function retranslateNow({ awaitPersisted = false } = {}) {
+  const s = state.settings;
+  if (!s) return;
+  if (!canRetranslateNow({
+    inputText: state.inputText,
+    engine: s.textTranslateEngine,
+    llmApiKey: s.llmConfig && s.llmConfig.apiKey,
+  })) return;
+  if (awaitPersisted) {
+    try { await saveSettings(); } catch (err) { /* fall back to the stale engine */ }
+  }
+  await translateText();
+}
+
 const app = document.querySelector("#app");
 const mode = window.__APP_MODE__ || "main";
 document.body.dataset.mode = mode.startsWith("overlay") ? "overlay" : "main";
@@ -235,6 +255,9 @@ function swapLanguages() {
   if (fromEl) fromEl.value = nextFrom;
   if (toEl) toEl.value = nextTo;
   saveSettings().catch(() => {});
+  // The swap button changes both languages at once, so the result on screen is
+  // stale for the same reason a dropdown change is.
+  retranslateNow().catch(() => {});
 }
 
 function shortcutKeysHtml(hk) {
@@ -465,8 +488,9 @@ function renderMain() {
       translateText();
     }, 0);
   });
-  document.querySelector("#from-lang").addEventListener("change", e => { state.settings.fromLang = e.target.value; saveSettings().catch(()=>{}); });
-  document.querySelector("#to-lang").addEventListener("change", e => { state.settings.toLang = e.target.value; saveSettings().catch(()=>{}); });
+  // Switching language re-translates right away — no Enter needed.
+  document.querySelector("#from-lang").addEventListener("change", e => { state.settings.fromLang = e.target.value; saveSettings().catch(()=>{}); retranslateNow().catch(()=>{}); });
+  document.querySelector("#to-lang").addEventListener("change", e => { state.settings.toLang = e.target.value; saveSettings().catch(()=>{}); retranslateNow().catch(()=>{}); });
   document.querySelector("#lang-swap").addEventListener("click", e => {
     e.stopPropagation();
     swapLanguages();
@@ -514,6 +538,9 @@ function renderMain() {
       const newEngine = e.currentTarget.dataset.engine;
       state.settings.textTranslateEngine = newEngine;
       saveSettings().catch(() => {});
+      // The engine is read from the saved settings by the Rust side, so this one
+      // waits for the write before re-running the translation.
+      retranslateNow({ awaitPersisted: true }).catch(() => {});
       // Update active state
       document.querySelectorAll("#engine-switcher .engine-btn").forEach(b => b.classList.toggle("active", b.dataset.engine === newEngine));
       // Toggle LLM settings visibility

--- a/ui/retranslate.mjs
+++ b/ui/retranslate.mjs
@@ -1,0 +1,17 @@
+// When a language / engine dropdown is changed, the old result on screen was
+// produced with the *previous* options, so it is stale: the user had to press
+// Enter to get a result for the new selection. Re-run the translation right
+// away instead — but only when that can't make things worse than leaving the
+// stale (still readable) result in place.
+
+export function canRetranslateNow({ inputText, engine, llmApiKey } = {}) {
+  const text = typeof inputText === "string" ? inputText.trim() : "";
+  // Nothing typed: there is nothing to translate, and re-running would wipe the
+  // current output for no reason.
+  if (!text) return false;
+  // Switching to the AI engine without a key only produces an inline error,
+  // replacing a perfectly good result from the previous engine. The existing
+  // "请先在设置中配置 API Key" hint still shows up when the user asks for it.
+  if (engine === "llm" && !llmApiKey) return false;
+  return true;
+}

--- a/ui/retranslate.test.mjs
+++ b/ui/retranslate.test.mjs
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { canRetranslateNow } from "./retranslate.mjs";
+
+test("有已输入文本时，换语言可以立刻重翻", () => {
+  assert.equal(
+    canRetranslateNow({ inputText: "你好", engine: "bing", llmApiKey: "" }),
+    true,
+  );
+});
+
+test("输入框为空时不重翻，避免白刷一次输出", () => {
+  assert.equal(canRetranslateNow({ inputText: "", engine: "bing" }), false);
+  assert.equal(canRetranslateNow({ inputText: "   \n ", engine: "bing" }), false);
+  assert.equal(canRetranslateNow({ inputText: undefined, engine: "bing" }), false);
+});
+
+test("切到 AI 引擎但没配 Key 时不重翻，别把已有结果换成报错", () => {
+  assert.equal(
+    canRetranslateNow({ inputText: "你好", engine: "llm", llmApiKey: "" }),
+    false,
+  );
+  assert.equal(
+    canRetranslateNow({ inputText: "你好", engine: "llm", llmApiKey: "sk-x" }),
+    true,
+  );
+});
+
+test("参数缺失时按不重翻处理", () => {
+  assert.equal(canRetranslateNow(), false);
+  assert.equal(canRetranslateNow({}), false);
+});


### PR DESCRIPTION
接着 #17 里「都得按回车」的另一半：#18 治的是输入法，这条治的是**换语言/换引擎时输出区不动**，还得再按一次回车才看得到新语言的译文。

改动只碰 `ui/`，判断条件抽在 `ui/retranslate.mjs` 的 `canRetranslateNow` 里，app.js 就多一个 `retranslateNow()`。

几点说明：

- 源语言/目标语言是 `translate_text` 的入参，所以 `change` 里存完设置直接重翻就行；
- 引擎那个不一样，它是 Rust 侧从已保存的 settings 里读的（`translate_text` 只收 `text/from_lang/to_lang`），所以这条走 `retranslateNow({ awaitPersisted: true })`，先 `await save_settings` 再翻，不然会拿旧引擎又跑一遍；
- 两种情况故意**不**重翻：输入框是空的；以及刚切到「AI 大模型」但 Key 还没填——那种时候重翻只会把一份本来能看的结果刷成「请先在设置中配置 API Key」。

验证是拿真的 app.js 在 headless Edge 里跑的（`window.__TAURI__` 打了个桩，记录每次 `translate_text` 的参数和调用顺序），桩里 `ProxySettings`… 呃，桩里的假翻译把目标语言写进结果，好让输出肉眼可见：

| 操作 | main | 这个分支 |
| --- | --- | --- |
| 「你好」出 en 结果后，把目标语言切到 ja | 一个请求都不发，输出还是 `[你好 ->en]` | 发 `你好\|auto->ja`，输出 `[你好 ->ja]` |
| 再把引擎 bing 切到 google | 只有 `save_settings` | `save_settings` → `translate_text`，顺序对，用的新引擎 |
| 切到 llm 且没配 Key | 不动 | 不动（保住 `[你好 ->ja]`） |
| 输入框为空时切语言 | 不动 | 不动 |

打字自动翻、Enter 立即翻、Shift+Enter 换行、粘贴立即翻这些行为都没动。`node --test ui/retranslate.test.mjs ui/focus-helpers.test.mjs` → 9 pass（新增 4 条）。

跟 #18 是两个各自基于 main 的独立分支，先合哪个都行；两边都在 app.js 顶部加了一行 import，真撞上了我 rebase 一下就是。
