### PR TITLE
fix(windows): 修复混 DPI 多屏截图整屏黑

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ objc2-app-kit = { version = "0.2.2", features = ["NSWindow", "NSEvent"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.55"
+window-vibrancy = "0.6"
 
 [features]
 default = ["custom-protocol"]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,7 +40,10 @@ objc2-app-kit = { version = "0.2.2", features = ["NSWindow", "NSEvent"] }
 winreg = "0.55"
 
 [features]
-default = []
+default = ["custom-protocol"]
+# Required for release builds: without this, Tauri keeps cfg(dev) and loads
+# http://127.0.0.1:1420 instead of the embedded ../ui assets.
+custom-protocol = ["tauri/custom-protocol"]
 
 # Speed up screenshot capture and image processing in debug builds.
 # BitBlt drops from ~473ms to ~50-100ms with opt-level=2.

--- a/src-tauri/src/capture.rs
+++ b/src-tauri/src/capture.rs
@@ -313,23 +313,44 @@ fn get_cursor_position() -> Result<(i32, i32), String> {
 // ── Screen capture ──────────────────────────────────────────────────────────
 
 /// Capture the screen to raw RGBA bytes in memory (no file I/O).
-#[cfg(not(target_os = "macos"))]
+///
+/// On Windows, `display-info` geometry is already in the process DPI space and
+/// `screenshots::Screen::capture()` multiplies by `scale_factor` again, which
+/// breaks mixed-DPI layouts (e.g. 100% + 125%) and yields a black overlay.
+/// Use `capture_area_ignore_area_check` with the reported size instead.
+#[cfg(target_os = "windows")]
+pub fn capture_screen_to_memory(screen: CaptureScreen) -> AppResult<(Vec<u8>, u32, u32)> {
+    let t0 = std::time::Instant::now();
+    let info = screen.display_info;
+    let capture = screen
+        .capture_area_ignore_area_check(0, 0, info.width, info.height)
+        .map_err(|e| AppError::Capture(e.to_string()))?;
+    tracing::info!(
+        "[PERF][capture] screen.capture_area_ignore_area_check (BitBlt): {:?}",
+        t0.elapsed()
+    );
+
+    let w = capture.width();
+    let h = capture.height();
+    let rgba_bytes = capture.into_raw();
+    tracing::info!(
+        "[PERF][capture] raw RGBA bytes: {} ({:.1} MB), {}x{}",
+        rgba_bytes.len(),
+        rgba_bytes.len() as f64 / 1_048_576.0,
+        w,
+        h
+    );
+
+    Ok((rgba_bytes, w, h))
+}
+
+/// Capture the screen to raw RGBA bytes in memory (no file I/O).
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
 pub fn capture_screen_to_memory(screen: CaptureScreen) -> AppResult<(Vec<u8>, u32, u32)> {
     let t0 = std::time::Instant::now();
     let capture = screen
         .capture()
         .map_err(|e| AppError::Capture(e.to_string()))?;
-    #[cfg(target_os = "windows")]
-    tracing::info!(
-        "[PERF][capture] screen.capture() (BitBlt): {:?}",
-        t0.elapsed()
-    );
-    #[cfg(target_os = "macos")]
-    tracing::info!(
-        "[PERF][capture] screen.capture() (CoreGraphics): {:?}",
-        t0.elapsed()
-    );
-    #[cfg(target_os = "linux")]
     tracing::info!("[PERF][capture] screen.capture(): {:?}", t0.elapsed());
 
     let w = capture.width();
@@ -374,9 +395,12 @@ pub fn capture_virtual_desktop_to_memory() -> AppResult<VirtualDesktopCapture> {
     let mut snapshots = Vec::with_capacity(screens.len());
     for screen in screens {
         let info = &screen.display_info;
-        // `display-info` exposes logical geometry, while `screenshots` returns
-        // physical RGBA pixels after multiplying by this display's scale factor.
-        // Convert both position and extent before composing mixed-DPI displays.
+        // Windows: display-info x/y/width/height are already physical pixels.
+        // Linux/other: treat them as logical and scale to match Screen::capture().
+        #[cfg(target_os = "windows")]
+        let (x, y, expected_width, expected_height) =
+            (info.x, info.y, info.width, info.height);
+        #[cfg(not(target_os = "windows"))]
         let (x, y, expected_width, expected_height) = physical_display_geometry(
             info.x,
             info.y,
@@ -432,6 +456,7 @@ pub fn capture_virtual_desktop_to_memory() -> AppResult<VirtualDesktopCapture> {
     })
 }
 
+#[cfg(not(target_os = "windows"))]
 fn physical_display_geometry(
     x: i32,
     y: i32,
@@ -492,8 +517,11 @@ fn virtual_desktop_bounds(monitors: &[(i32, i32, u32, u32)]) -> AppResult<(i32, 
 
 #[cfg(test)]
 mod tests {
-    use super::{physical_display_geometry, virtual_desktop_bounds};
+    #[cfg(not(target_os = "windows"))]
+    use super::physical_display_geometry;
+    use super::virtual_desktop_bounds;
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn display_geometry_is_converted_to_physical_pixels() {
         assert_eq!(

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -408,7 +408,10 @@ async fn begin_capture_impl(app: &AppHandle, state: &SharedState) -> AppResult<(
     #[cfg(target_os = "macos")]
     capture_timeline(&t0, "begin_capture_impl entered");
 
-    let restore_main_window = hide_main_window_before_capture(app);
+    // Hide the main window for a clean capture, but do not bring it back
+    // afterward — screenshot results live on the overlay; reopen from tray.
+    let _ = hide_main_window_before_capture(app);
+    let restore_main_window = false;
 
     #[cfg(target_os = "macos")]
     capture_timeline(&t0, "main window hidden");

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -520,33 +520,62 @@ async fn begin_capture_impl(app: &AppHandle, state: &SharedState) -> AppResult<(
         );
 
         let scale_factor = monitor.scale_factor;
-        // Capture every display into one virtual desktop so one selection can
-        // cross monitor boundaries without restarting the screenshot flow.
-        let desktop = tokio::task::spawn_blocking(capture::capture_virtual_desktop_to_memory)
+
+        // Windows: a single softbuffer HWND spanning the mixed-DPI virtual
+        // desktop paints black on this machine. Capture only the monitor under
+        // the cursor and use borderless fullscreen (monitor_count=1).
+        #[cfg(target_os = "windows")]
+        let (rgba, w, h, origin_x, origin_y, monitor_count) = {
+            let screen = result.screen;
+            let (rgba, w, h) = tokio::task::spawn_blocking(move || {
+                capture::capture_screen_to_memory(screen)
+            })
             .await
             .map_err(|e| AppError::Capture(format!("capture task failed: {e}")))??;
-        let rgba = desktop.rgba;
-        let w = desktop.width;
-        let h = desktop.height;
+            tracing::info!(
+                "[PERF] capture_cursor_monitor: {:?} | {}x{} ({:.1} MB RGBA)",
+                t0.elapsed(),
+                w,
+                h,
+                rgba.len() as f64 / 1_048_576.0
+            );
+            (rgba, w, h, monitor.x, monitor.y, 1usize)
+        };
 
-        tracing::info!(
-            "[PERF] capture_virtual_desktop: {:?} | {} displays, {}x{} ({:.1} MB RGBA)",
-            t0.elapsed(),
-            desktop.monitor_count,
-            w,
-            h,
-            rgba.len() as f64 / 1_048_576.0
-        );
+        #[cfg(not(target_os = "windows"))]
+        let (rgba, w, h, origin_x, origin_y, monitor_count) = {
+            // Capture every display into one virtual desktop so one selection can
+            // cross monitor boundaries without restarting the screenshot flow.
+            let desktop = tokio::task::spawn_blocking(capture::capture_virtual_desktop_to_memory)
+                .await
+                .map_err(|e| AppError::Capture(format!("capture task failed: {e}")))??;
+            tracing::info!(
+                "[PERF] capture_virtual_desktop: {:?} | {} displays, {}x{} ({:.1} MB RGBA)",
+                t0.elapsed(),
+                desktop.monitor_count,
+                desktop.width,
+                desktop.height,
+                desktop.rgba.len() as f64 / 1_048_576.0
+            );
+            (
+                desktop.rgba,
+                desktop.width,
+                desktop.height,
+                desktop.x,
+                desktop.y,
+                desktop.monitor_count,
+            )
+        };
 
         *state.capture_session.write().await = Some(crate::app_state::ActiveCaptureSession {
             rgba: rgba.clone(),
             img_w: w,
             img_h: h,
             scale_factor,
-            monitor_x: desktop.x,
-            monitor_y: desktop.y,
-            monitor_width: desktop.width,
-            monitor_height: desktop.height,
+            monitor_x: origin_x,
+            monitor_y: origin_y,
+            monitor_width: w,
+            monitor_height: h,
             preview_image_base64: None,
             preview_image_mime: String::new(),
             restore_main_window,
@@ -554,7 +583,14 @@ async fn begin_capture_impl(app: &AppHandle, state: &SharedState) -> AppResult<(
 
         let (event_tx, event_rx) = mpsc::channel::<CaptureEvent>();
         capture_window::start_capture(
-            rgba.clone(), w, h, scale_factor, desktop.x, desktop.y, desktop.monitor_count, event_tx,
+            rgba.clone(),
+            w,
+            h,
+            scale_factor,
+            origin_x,
+            origin_y,
+            monitor_count,
+            event_tx,
         );
         tracing::info!("[PERF] start_capture_native: {:?}", t0.elapsed());
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -409,7 +409,7 @@ async fn begin_capture_impl(app: &AppHandle, state: &SharedState) -> AppResult<(
     capture_timeline(&t0, "begin_capture_impl entered");
 
     // Hide the main window for a clean capture, but do not bring it back
-    // afterward — screenshot results live on the overlay; reopen from tray.
+    // afterward: screenshot results live on the overlay; reopen from tray.
     let _ = hide_main_window_before_capture(app);
     let restore_main_window = false;
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -192,12 +192,12 @@ fn main() {
             // ── Intercept window close → hide to tray ────────────────────
             let main_window = app.get_webview_window("main").unwrap();
 
-            // DeskBox-like frosted glass: OS acrylic behind a transparent WebView.
+            // DeskBox / WinUI-like light Mica behind the WebView (not heavy Acrylic).
             #[cfg(target_os = "windows")]
             {
-                use window_vibrancy::apply_acrylic;
-                // Soft light acrylic tint (approx. weather-widget glass).
-                let _ = apply_acrylic(&main_window, Some((236, 240, 248, 180)));
+                use window_vibrancy::apply_mica;
+                // Some(false) = light mica (Win11); falls back quietly on older builds.
+                let _ = apply_mica(&main_window, Some(false));
             }
 
             // Silent startup: when launched via OS autostart the app is run with

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -192,6 +192,14 @@ fn main() {
             // ── Intercept window close → hide to tray ────────────────────
             let main_window = app.get_webview_window("main").unwrap();
 
+            // DeskBox-like frosted glass: OS acrylic behind a transparent WebView.
+            #[cfg(target_os = "windows")]
+            {
+                use window_vibrancy::apply_acrylic;
+                // Soft light acrylic tint (approx. weather-widget glass).
+                let _ = apply_acrylic(&main_window, Some((236, 240, 248, 180)));
+            }
+
             // Silent startup: when launched via OS autostart the app is run with
             // `--minimized`, so keep the main window hidden (tray only). The window
             // is created hidden (see tauri.conf.json), so a normal launch must

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,7 +26,8 @@
         "minHeight": 88,
         "decorations": true,
         "shadow": true,
-        "backgroundColor": "#F3F4F6",
+        "transparent": true,
+        "backgroundColor": "#00000000",
         "visible": false
       }
     ]

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -1,16 +1,30 @@
 :root {
-  --bg-app: #F3F4F6;
-  --block-bg: #FFFFFF;
+  /* DeskBox / weather-widget inspired frosted glass */
+  --bg-app: transparent;
+  --glass-fill: rgba(255, 255, 255, 0.42);
+  --glass-fill-strong: rgba(255, 255, 255, 0.58);
+  --glass-fill-soft: rgba(255, 255, 255, 0.28);
+  --glass-border: rgba(120, 160, 255, 0.38);
+  --glass-border-soft: rgba(255, 255, 255, 0.55);
+  --glass-highlight: rgba(255, 255, 255, 0.65);
+  --block-bg: rgba(255, 255, 255, 0.48);
   --accent: #FFCC00;
-  --text-main: #111827;
-  --text-sub: #6B7280;
-  --radius-xl: 20px;
+  --accent-glow: rgba(255, 204, 0, 0.35);
+  --text-main: #1c1c1e;
+  --text-sub: #5c6370;
+  --radius-xl: 18px;
   --radius-md: 14px;
   --radius-sm: 8px;
+  --shadow-glass: 0 8px 32px rgba(30, 50, 90, 0.12), inset 0 1px 0 var(--glass-highlight);
   font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Segoe UI", "Microsoft YaHei", sans-serif;
 }
 * { box-sizing: border-box; margin: 0; padding: 0; }
-html, body, #app { width: 100%; height: 100%; background: var(--bg-app); color: var(--text-main); }
+html, body, #app {
+  width: 100%;
+  height: 100%;
+  background: transparent;
+  color: var(--text-main);
+}
 button, select, input, textarea { font: inherit; }
 
 html.capture-preparing,
@@ -32,11 +46,19 @@ body.capture-preparing *::after {
   transition: none !important;
 }
 
-/* ── Bento container ── */
+/* ── Bento container (frosted shell) ── */
 .bento-app {
   width: 100%;
   height: 100%;
-  background: var(--bg-app);
+  background:
+    radial-gradient(120% 80% at 100% 0%, rgba(140, 170, 255, 0.22), transparent 55%),
+    radial-gradient(90% 70% at 0% 100%, rgba(255, 255, 255, 0.35), transparent 50%),
+    var(--glass-fill);
+  -webkit-backdrop-filter: blur(28px) saturate(1.35);
+  backdrop-filter: blur(28px) saturate(1.35);
+  border: 1px solid var(--glass-border);
+  border-radius: 16px;
+  box-shadow: var(--shadow-glass);
   padding: 12px;
   display: flex;
   flex-direction: column;
@@ -46,9 +68,12 @@ body.capture-preparing *::after {
 /* ── Generic block card ── */
 .block {
   background: var(--block-bg);
+  -webkit-backdrop-filter: blur(16px) saturate(1.2);
+  backdrop-filter: blur(16px) saturate(1.2);
+  border: 1px solid var(--glass-border-soft);
   border-radius: var(--radius-xl);
   padding: 16px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.02);
+  box-shadow: 0 4px 18px rgba(30, 50, 90, 0.06), inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
 
 /* ── Header: language + toggle ── */
@@ -68,6 +93,7 @@ body.capture-preparing *::after {
   font-size: 15px;
   font-weight: 700;
   color: var(--text-main);
+  letter-spacing: 0.01em;
 }
 .header-right {
   display: flex;
@@ -100,9 +126,9 @@ body.capture-preparing *::after {
   padding: 2px 4px;
   border-radius: 6px;
 }
-.lang-pill select:hover { background: rgba(0,0,0,0.04); }
+.lang-pill select:hover { background: rgba(255,255,255,0.35); }
 .lang-swap {
-  color: #A1A1AA;
+  color: #8b93a3;
   font-size: 14px;
   line-height: 1;
   background: none;
@@ -112,7 +138,7 @@ body.capture-preparing *::after {
   border-radius: 6px;
 }
 .lang-swap:hover {
-  background: rgba(0,0,0,0.04);
+  background: rgba(255,255,255,0.35);
   color: var(--text-main);
 }
 
@@ -120,11 +146,11 @@ body.capture-preparing *::after {
 .toggle {
   width: 32px;
   height: 18px;
-  background: #E4E4E7;
+  background: rgba(120, 130, 150, 0.28);
   border-radius: 20px;
   position: relative;
   cursor: pointer;
-  border: none;
+  border: 1px solid rgba(255,255,255,0.35);
   padding: 0;
   transition: background 0.2s;
   flex-shrink: 0;
@@ -138,17 +164,18 @@ body.capture-preparing *::after {
   height: 14px;
   background: white;
   border-radius: 50%;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.12);
   transition: transform 0.2s, background 0.2s;
 }
-.toggle.on { background: var(--accent); }
+.toggle.on { background: var(--accent); box-shadow: 0 0 12px var(--accent-glow); }
 .toggle.on::after { transform: translateX(14px); }
 
 /* Engine switcher */
 .engine-switcher {
   display: flex;
   gap: 0;
-  background: #F4F4F5;
+  background: var(--glass-fill-soft);
+  border: 1px solid rgba(255,255,255,0.4);
   border-radius: 8px;
   padding: 2px;
 }
@@ -166,29 +193,30 @@ body.capture-preparing *::after {
 }
 .engine-btn:hover { color: var(--text-main); }
 .engine-btn.active {
-  background: var(--block-bg);
+  background: rgba(255,255,255,0.72);
   color: var(--text-main);
-  box-shadow: 0 1px 2px rgba(0,0,0,0.06);
+  box-shadow: 0 1px 3px rgba(30,50,90,0.08);
 }
 
 /* Settings panel */
 .settings-panel {
   background: var(--block-bg);
+  -webkit-backdrop-filter: blur(16px) saturate(1.2);
+  backdrop-filter: blur(16px) saturate(1.2);
+  border: 1px solid var(--glass-border-soft);
   border-radius: var(--radius-xl);
   padding: 14px 16px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.02);
+  box-shadow: 0 4px 18px rgba(30, 50, 90, 0.06), inset 0 1px 0 rgba(255, 255, 255, 0.7);
   flex: 1 1 auto;
   min-height: 0;
-  /* Scroll with the wheel when content overflows, but never show a scrollbar
-     (its appearance/disappearance during the resize caused a flash). */
   overflow-y: auto;
-  scrollbar-width: none; /* Firefox */
-  -ms-overflow-style: none; /* old Edge */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 }
 .settings-panel::-webkit-scrollbar {
   width: 0;
   height: 0;
-  display: none; /* Chromium / WebView2 */
+  display: none;
 }
 .settings-section {
   display: flex;
@@ -216,7 +244,7 @@ body.capture-preparing *::after {
   border-radius: 6px;
   transition: all 0.15s;
 }
-.settings-btn:hover { color: var(--text-main); background: rgba(0,0,0,0.04); }
+.settings-btn:hover { color: var(--text-main); background: rgba(255,255,255,0.4); }
 .settings-btn.open { color: var(--accent); }
 
 .pin-btn {
@@ -231,32 +259,23 @@ body.capture-preparing *::after {
   padding: 4px;
   border-radius: 6px;
   transition: all 0.15s;
-  /* 斜过来 = 图钉被拔起来了（未置顶）；摆正 + 填充 = 钉住（置顶）。
-     图标本身画成正立的，所以这里的角度就是用户实际看到的角度。 */
   transform: rotate(-45deg);
 }
 .pin-btn svg { display: block; fill: none; stroke: currentColor; stroke-width: 1.4; stroke-linejoin: round; }
-.pin-btn:hover { color: var(--text-main); background: rgba(0,0,0,0.04); }
+.pin-btn:hover { color: var(--text-main); background: rgba(255,255,255,0.4); }
 .pin-btn.on { color: var(--accent); transform: rotate(0deg); }
 .pin-btn.on svg { fill: currentColor; stroke: none; }
 
 /* ── Collapse: 窗口拉到只剩横栏时先收掉输入/输出 ── */
-/* 横栏本身 flex-shrink:0，最小高度就是它 + 上下 padding；正文一矮到没法用就
-   整个收起来，而不是让用户拖不动。设置面板展开时不收（那时窗口会被撑开）。 */
 @media (max-height: 176px) {
   .bento-app:not(.settings-open) .text-block { display: none; }
 }
-/* 横栏里的东西在窄窗口下按重要性依次让位：标题、按钮文字。 */
 @media (max-width: 440px) {
   .header-block .app-title { display: none; }
   .header-block .capture-btn .btn-label { display: none; }
 }
 
 /* ── Text block: left input + right output ── */
-/* The translation area fills the window when settings are collapsed. When the
-   settings panel is visible (window grows), its height is capped so it stays
-   the same size and the extra vertical space is absorbed by the settings
-   panel below. */
 .text-block {
   display: flex;
   flex-direction: row;
@@ -277,7 +296,7 @@ body.capture-preparing *::after {
 }
 .input-col {
   padding-right: 10px;
-  border-right: 1px solid #F0F0F2;
+  border-right: 1px solid rgba(120, 140, 180, 0.18);
 }
 .output-col {
   padding-left: 10px;
@@ -309,7 +328,7 @@ body.capture-preparing *::after {
   padding-right: 8px;
   overflow-y: auto;
 }
-.input-area::placeholder { color: #D4D4D8; }
+.input-area::placeholder { color: rgba(92, 99, 112, 0.55); }
 .meta-info {
   display: flex;
   justify-content: space-between;
@@ -321,7 +340,8 @@ body.capture-preparing *::after {
   gap: 4px;
 }
 .detect-tag {
-  background: #F4F4F5;
+  background: rgba(255,255,255,0.45);
+  border: 1px solid rgba(255,255,255,0.5);
   padding: 2px 6px;
   border-radius: 6px;
   font-weight: 500;
@@ -347,7 +367,6 @@ body.capture-preparing *::after {
   overflow-y: auto;
 }
 
-/* Ensure output textarea also fills available space like input textarea */
 .output-area {
   flex: 1;
   min-height: 0;
@@ -374,7 +393,8 @@ body.capture-preparing *::after {
   gap: 6px;
 }
 .alt-tag {
-  background: #F4F4F5;
+  background: rgba(255,255,255,0.45);
+  border: 1px solid rgba(255,255,255,0.5);
   padding: 3px 8px;
   border-radius: 6px;
   font-size: 12px;
@@ -399,7 +419,7 @@ body.capture-preparing *::after {
   gap: 4px;
   line-height: 1;
 }
-.capture-btn:hover { color: var(--text-main); background: rgba(0,0,0,0.04); }
+.capture-btn:hover { color: var(--text-main); background: rgba(255,255,255,0.4); }
 .capture-btn:disabled { opacity: 0.4; cursor: default; }
 .capture-shortcut {
   display: inline-flex;
@@ -409,7 +429,8 @@ body.capture-preparing *::after {
   color: var(--text-sub);
 }
 .capture-shortcut .shortcut-key {
-  background: var(--bg-app);
+  background: rgba(255,255,255,0.5);
+  border: 1px solid rgba(255,255,255,0.55);
   color: var(--text-main);
   font-family: monospace;
   font-size: 10px;
@@ -420,19 +441,20 @@ body.capture-preparing *::after {
 /* ── Shortcut row ── */
 .shortcut-row {
   font-size: 12px;
-  color: #A1A1AA;
+  color: #8b93a3;
   display: flex;
   align-items: center;
   gap: 4px;
   cursor: pointer;
   user-select: none;
 }
-.shortcut-row:hover { color: #D4D4D8; }
+.shortcut-row:hover { color: var(--text-main); }
 .shortcut-key {
-  background: rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.55);
+  border: 1px solid rgba(255,255,255,0.5);
   padding: 2px 6px;
   border-radius: 4px;
-  color: white;
+  color: var(--text-main);
   font-family: monospace;
   font-size: 12px;
 }
@@ -442,16 +464,17 @@ body.capture-preparing *::after {
   color: #71717A;
   margin-left: 6px;
 }
-.shortcut-row:hover .shortcut-hint { color: #D4D4D8; }
+.shortcut-row:hover .shortcut-hint { color: var(--text-sub); }
 .shortcut-row.recording .shortcut-key {
-  background: rgba(255,204,0,0.2);
+  background: rgba(255,204,0,0.22);
   color: var(--accent);
+  border-color: rgba(255,204,0,0.35);
 }
 .settings-shortcut {
   color: var(--text-sub);
 }
 .settings-shortcut .shortcut-key {
-  background: var(--bg-app);
+  background: rgba(255,255,255,0.5);
   color: var(--text-main);
 }
 .settings-shortcut .shortcut-hint {
@@ -460,8 +483,8 @@ body.capture-preparing *::after {
 
 /* Settings input fields (LLM config) */
 .settings-input {
-  background: var(--bg-app);
-  border: 1px solid #E4E4E7;
+  background: rgba(255,255,255,0.45);
+  border: 1px solid rgba(160, 175, 210, 0.35);
   border-radius: var(--radius-sm);
   padding: 4px 8px;
   font-size: 12px;
@@ -471,21 +494,20 @@ body.capture-preparing *::after {
   margin-left: 12px;
   text-align: right;
   outline: none;
-  transition: border-color 0.15s;
+  transition: border-color 0.15s, background 0.15s;
 }
-/* Keep labels from being squeezed so the input can grow to fill the row. */
 .settings-row > .settings-label {
   flex: 0 0 auto;
   white-space: nowrap;
 }
 .settings-input:focus {
-  border-color: var(--accent);
+  border-color: rgba(120, 160, 255, 0.65);
+  background: rgba(255,255,255,0.7);
 }
 .settings-input::placeholder {
-  color: #D4D4D8;
+  color: rgba(92, 99, 112, 0.5);
 }
 
-/* Prompt row: label on top, full-width textarea below. */
 .settings-row-vertical {
   flex-direction: column;
   align-items: stretch;
@@ -546,14 +568,17 @@ body[data-mode="overlay"] {
 }
 .overlay-box {
   position: absolute;
-  background: rgba(255,255,255,0.96);
+  background: rgba(255,255,255,0.92);
+  -webkit-backdrop-filter: blur(16px);
+  backdrop-filter: blur(16px);
+  border: 1px solid rgba(120, 160, 255, 0.3);
   color: var(--text-main);
-  border-radius: 4px;
+  border-radius: 10px;
   padding: 10px 14px;
   font-size: 14px;
   line-height: 1.55;
   pointer-events: auto;
-  box-shadow: 0 4px 24px rgba(0,0,0,0.18);
+  box-shadow: 0 8px 28px rgba(30,50,90,0.16);
   max-width: 90vw;
 }
 

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -1,22 +1,22 @@
 :root {
-  /* DeskBox / weather-widget inspired frosted glass */
+  /* Closer to DeskBox / WinUI 3 light Fluent — not heavy acrylic bubbles */
   --bg-app: transparent;
-  --glass-fill: rgba(255, 255, 255, 0.42);
-  --glass-fill-strong: rgba(255, 255, 255, 0.58);
-  --glass-fill-soft: rgba(255, 255, 255, 0.28);
-  --glass-border: rgba(120, 160, 255, 0.38);
-  --glass-border-soft: rgba(255, 255, 255, 0.55);
-  --glass-highlight: rgba(255, 255, 255, 0.65);
-  --block-bg: rgba(255, 255, 255, 0.48);
-  --accent: #FFCC00;
-  --accent-glow: rgba(255, 204, 0, 0.35);
-  --text-main: #1c1c1e;
-  --text-sub: #5c6370;
-  --radius-xl: 18px;
-  --radius-md: 14px;
-  --radius-sm: 8px;
-  --shadow-glass: 0 8px 32px rgba(30, 50, 90, 0.12), inset 0 1px 0 var(--glass-highlight);
-  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Segoe UI", "Microsoft YaHei", sans-serif;
+  --surface: rgba(255, 255, 255, 0.72);
+  --surface-solid: #ffffff;
+  --surface-subtle: rgba(249, 249, 249, 0.88);
+  --stroke: rgba(0, 0, 0, 0.06);
+  --stroke-strong: rgba(0, 0, 0, 0.09);
+  --block-bg: var(--surface);
+  --accent: #0078d4;
+  --accent-soft: rgba(0, 120, 212, 0.12);
+  --accent-warn: #FFCC00;
+  --text-main: #1a1a1a;
+  --text-sub: #5d5d5d;
+  --radius-xl: 8px;
+  --radius-md: 6px;
+  --radius-sm: 4px;
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.04), 0 2px 8px rgba(0, 0, 0, 0.04);
+  font-family: "Segoe UI Variable", "Segoe UI", "Microsoft YaHei UI", "Microsoft YaHei", sans-serif;
 }
 * { box-sizing: border-box; margin: 0; padding: 0; }
 html, body, #app {
@@ -46,43 +46,38 @@ body.capture-preparing *::after {
   transition: none !important;
 }
 
-/* ── Bento container (frosted shell) ── */
+/* Flat Fluent shell — no nested blue glass frame */
 .bento-app {
   width: 100%;
   height: 100%;
-  background:
-    radial-gradient(120% 80% at 100% 0%, rgba(140, 170, 255, 0.22), transparent 55%),
-    radial-gradient(90% 70% at 0% 100%, rgba(255, 255, 255, 0.35), transparent 50%),
-    var(--glass-fill);
-  -webkit-backdrop-filter: blur(28px) saturate(1.35);
-  backdrop-filter: blur(28px) saturate(1.35);
-  border: 1px solid var(--glass-border);
-  border-radius: 16px;
-  box-shadow: var(--shadow-glass);
-  padding: 12px;
+  background: rgba(243, 243, 243, 0.55);
+  padding: 10px 12px 12px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
 }
 
-/* ── Generic block card ── */
 .block {
-  background: var(--block-bg);
-  -webkit-backdrop-filter: blur(16px) saturate(1.2);
-  backdrop-filter: blur(16px) saturate(1.2);
-  border: 1px solid var(--glass-border-soft);
+  background: var(--surface-solid);
+  border: 1px solid var(--stroke);
   border-radius: var(--radius-xl);
-  padding: 16px;
-  box-shadow: 0 4px 18px rgba(30, 50, 90, 0.06), inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  padding: 14px 16px;
+  box-shadow: var(--shadow-card);
 }
 
-/* ── Header: language + toggle ── */
 .header-block {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 16px;
+  padding: 8px 12px;
   flex-shrink: 0;
+  background: var(--surface-solid);
+  border: 1px solid var(--stroke);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-card);
 }
 .header-left {
   display: flex;
@@ -90,15 +85,14 @@ body.capture-preparing *::after {
   gap: 12px;
 }
 .app-title {
-  font-size: 15px;
-  font-weight: 700;
+  font-size: 14px;
+  font-weight: 600;
   color: var(--text-main);
-  letter-spacing: 0.01em;
 }
 .header-right {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
 }
 .autostart-label {
   font-size: 12px;
@@ -109,7 +103,7 @@ body.capture-preparing *::after {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
   color: var(--text-main);
 }
@@ -117,42 +111,41 @@ body.capture-preparing *::after {
   background: transparent;
   border: none;
   color: var(--text-main);
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
   cursor: pointer;
   outline: none;
   appearance: none;
   -webkit-appearance: none;
   padding: 2px 4px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
 }
-.lang-pill select:hover { background: rgba(255,255,255,0.35); }
+.lang-pill select:hover { background: rgba(0,0,0,0.04); }
 .lang-swap {
-  color: #8b93a3;
+  color: #8a8a8a;
   font-size: 14px;
   line-height: 1;
   background: none;
   border: none;
   cursor: pointer;
   padding: 2px 6px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
 }
 .lang-swap:hover {
-  background: rgba(255,255,255,0.35);
+  background: rgba(0,0,0,0.04);
   color: var(--text-main);
 }
 
-/* Toggle */
 .toggle {
-  width: 32px;
-  height: 18px;
-  background: rgba(120, 130, 150, 0.28);
+  width: 40px;
+  height: 20px;
+  background: #c8c8c8;
   border-radius: 20px;
   position: relative;
   cursor: pointer;
-  border: 1px solid rgba(255,255,255,0.35);
+  border: none;
   padding: 0;
-  transition: background 0.2s;
+  transition: background 0.15s;
   flex-shrink: 0;
 }
 .toggle::after {
@@ -160,24 +153,23 @@ body.capture-preparing *::after {
   position: absolute;
   left: 2px;
   top: 2px;
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
   background: white;
   border-radius: 50%;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.12);
-  transition: transform 0.2s, background 0.2s;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.18);
+  transition: transform 0.15s;
 }
-.toggle.on { background: var(--accent); box-shadow: 0 0 12px var(--accent-glow); }
-.toggle.on::after { transform: translateX(14px); }
+.toggle.on { background: var(--accent); }
+.toggle.on::after { transform: translateX(20px); }
 
-/* Engine switcher */
 .engine-switcher {
   display: flex;
   gap: 0;
-  background: var(--glass-fill-soft);
-  border: 1px solid rgba(255,255,255,0.4);
-  border-radius: 8px;
+  background: #f0f0f0;
+  border-radius: var(--radius-md);
   padding: 2px;
+  border: 1px solid var(--stroke);
 }
 .engine-btn {
   background: none;
@@ -187,26 +179,23 @@ body.capture-preparing *::after {
   font-weight: 500;
   color: var(--text-sub);
   padding: 4px 10px;
-  border-radius: 6px;
-  transition: all 0.15s;
+  border-radius: 4px;
+  transition: all 0.12s;
   white-space: nowrap;
 }
 .engine-btn:hover { color: var(--text-main); }
 .engine-btn.active {
-  background: rgba(255,255,255,0.72);
+  background: #fff;
   color: var(--text-main);
-  box-shadow: 0 1px 3px rgba(30,50,90,0.08);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.06);
 }
 
-/* Settings panel */
 .settings-panel {
-  background: var(--block-bg);
-  -webkit-backdrop-filter: blur(16px) saturate(1.2);
-  backdrop-filter: blur(16px) saturate(1.2);
-  border: 1px solid var(--glass-border-soft);
+  background: var(--surface-solid);
+  border: 1px solid var(--stroke);
   border-radius: var(--radius-xl);
-  padding: 14px 16px;
-  box-shadow: 0 4px 18px rgba(30, 50, 90, 0.06), inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  padding: 12px 14px;
+  box-shadow: var(--shadow-card);
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
@@ -241,10 +230,10 @@ body.capture-preparing *::after {
   line-height: 1;
   color: var(--text-sub);
   padding: 4px;
-  border-radius: 6px;
-  transition: all 0.15s;
+  border-radius: var(--radius-sm);
+  transition: all 0.12s;
 }
-.settings-btn:hover { color: var(--text-main); background: rgba(255,255,255,0.4); }
+.settings-btn:hover { color: var(--text-main); background: rgba(0,0,0,0.04); }
 .settings-btn.open { color: var(--accent); }
 
 .pin-btn {
@@ -257,16 +246,15 @@ body.capture-preparing *::after {
   line-height: 1;
   color: var(--text-sub);
   padding: 4px;
-  border-radius: 6px;
-  transition: all 0.15s;
+  border-radius: var(--radius-sm);
+  transition: all 0.12s;
   transform: rotate(-45deg);
 }
 .pin-btn svg { display: block; fill: none; stroke: currentColor; stroke-width: 1.4; stroke-linejoin: round; }
-.pin-btn:hover { color: var(--text-main); background: rgba(255,255,255,0.4); }
+.pin-btn:hover { color: var(--text-main); background: rgba(0,0,0,0.04); }
 .pin-btn.on { color: var(--accent); transform: rotate(0deg); }
 .pin-btn.on svg { fill: currentColor; stroke: none; }
 
-/* ── Collapse: 窗口拉到只剩横栏时先收掉输入/输出 ── */
 @media (max-height: 176px) {
   .bento-app:not(.settings-open) .text-block { display: none; }
 }
@@ -275,7 +263,6 @@ body.capture-preparing *::after {
   .header-block .capture-btn .btn-label { display: none; }
 }
 
-/* ── Text block: left input + right output ── */
 .text-block {
   display: flex;
   flex-direction: row;
@@ -296,7 +283,7 @@ body.capture-preparing *::after {
 }
 .input-col {
   padding-right: 10px;
-  border-right: 1px solid rgba(120, 140, 180, 0.18);
+  border-right: 1px solid var(--stroke-strong);
 }
 .output-col {
   padding-left: 10px;
@@ -309,7 +296,7 @@ body.capture-preparing *::after {
   border: none;
   outline: none;
   resize: none;
-  font-size: 15px;
+  font-size: 14px;
   line-height: 1.5;
   color: var(--text-main);
   font-family: inherit;
@@ -324,11 +311,11 @@ body.capture-preparing *::after {
 .input-area {
   flex: 1;
   min-height: 0;
-  font-weight: 500;
+  font-weight: 400;
   padding-right: 8px;
   overflow-y: auto;
 }
-.input-area::placeholder { color: rgba(92, 99, 112, 0.55); }
+.input-area::placeholder { color: #9a9a9a; }
 .meta-info {
   display: flex;
   justify-content: space-between;
@@ -340,10 +327,9 @@ body.capture-preparing *::after {
   gap: 4px;
 }
 .detect-tag {
-  background: rgba(255,255,255,0.45);
-  border: 1px solid rgba(255,255,255,0.5);
+  background: #f3f3f3;
   padding: 2px 6px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-weight: 500;
   font-size: 11px;
   color: var(--text-sub);
@@ -355,8 +341,8 @@ body.capture-preparing *::after {
   color: var(--text-sub);
   font-size: 14px;
   padding: 2px 4px;
-  border-radius: 4px;
-  transition: color 0.15s;
+  border-radius: var(--radius-sm);
+  transition: color 0.12s;
   line-height: 1;
 }
 .tts-btn:hover { color: var(--text-main); }
@@ -380,7 +366,7 @@ body.capture-preparing *::after {
   min-height: 0;
 }
 .output-primary {
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 500;
   line-height: 1.5;
   color: var(--text-main);
@@ -393,10 +379,9 @@ body.capture-preparing *::after {
   gap: 6px;
 }
 .alt-tag {
-  background: rgba(255,255,255,0.45);
-  border: 1px solid rgba(255,255,255,0.5);
+  background: #f3f3f3;
   padding: 3px 8px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-size: 12px;
   font-weight: 500;
   color: var(--text-sub);
@@ -404,22 +389,21 @@ body.capture-preparing *::after {
   line-height: 1.4;
 }
 
-/* ── Capture button in header ── */
 .capture-btn {
   background: none;
   border: none;
   cursor: pointer;
   color: var(--text-sub);
-  font-size: 16px;
-  padding: 2px 6px;
-  border-radius: 6px;
-  transition: all 0.15s;
+  font-size: 15px;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  transition: all 0.12s;
   display: flex;
   align-items: center;
   gap: 4px;
   line-height: 1;
 }
-.capture-btn:hover { color: var(--text-main); background: rgba(255,255,255,0.4); }
+.capture-btn:hover { color: var(--text-main); background: rgba(0,0,0,0.04); }
 .capture-btn:disabled { opacity: 0.4; cursor: default; }
 .capture-shortcut {
   display: inline-flex;
@@ -429,19 +413,18 @@ body.capture-preparing *::after {
   color: var(--text-sub);
 }
 .capture-shortcut .shortcut-key {
-  background: rgba(255,255,255,0.5);
-  border: 1px solid rgba(255,255,255,0.55);
+  background: #f3f3f3;
   color: var(--text-main);
-  font-family: monospace;
+  font-family: "Cascadia Mono", Consolas, monospace;
   font-size: 10px;
   padding: 1px 4px;
   border-radius: 3px;
+  border: 1px solid var(--stroke);
 }
 
-/* ── Shortcut row ── */
 .shortcut-row {
   font-size: 12px;
-  color: #8b93a3;
+  color: var(--text-sub);
   display: flex;
   align-items: center;
   gap: 4px;
@@ -450,41 +433,40 @@ body.capture-preparing *::after {
 }
 .shortcut-row:hover { color: var(--text-main); }
 .shortcut-key {
-  background: rgba(255,255,255,0.55);
-  border: 1px solid rgba(255,255,255,0.5);
+  background: #f3f3f3;
+  border: 1px solid var(--stroke);
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: 3px;
   color: var(--text-main);
-  font-family: monospace;
+  font-family: "Cascadia Mono", Consolas, monospace;
   font-size: 12px;
 }
 .shortcut-row.recording { color: var(--accent); }
 .shortcut-hint {
   font-size: 11px;
-  color: #71717A;
+  color: #8a8a8a;
   margin-left: 6px;
 }
 .shortcut-row:hover .shortcut-hint { color: var(--text-sub); }
 .shortcut-row.recording .shortcut-key {
-  background: rgba(255,204,0,0.22);
+  background: var(--accent-soft);
   color: var(--accent);
-  border-color: rgba(255,204,0,0.35);
+  border-color: rgba(0, 120, 212, 0.28);
 }
 .settings-shortcut {
   color: var(--text-sub);
 }
 .settings-shortcut .shortcut-key {
-  background: rgba(255,255,255,0.5);
+  background: #f3f3f3;
   color: var(--text-main);
 }
 .settings-shortcut .shortcut-hint {
   color: var(--text-sub);
 }
 
-/* Settings input fields (LLM config) */
 .settings-input {
-  background: rgba(255,255,255,0.45);
-  border: 1px solid rgba(160, 175, 210, 0.35);
+  background: #fff;
+  border: 1px solid var(--stroke-strong);
   border-radius: var(--radius-sm);
   padding: 4px 8px;
   font-size: 12px;
@@ -494,18 +476,18 @@ body.capture-preparing *::after {
   margin-left: 12px;
   text-align: right;
   outline: none;
-  transition: border-color 0.15s, background 0.15s;
+  transition: border-color 0.12s;
 }
 .settings-row > .settings-label {
   flex: 0 0 auto;
   white-space: nowrap;
 }
 .settings-input:focus {
-  border-color: rgba(120, 160, 255, 0.65);
-  background: rgba(255,255,255,0.7);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent-soft);
 }
 .settings-input::placeholder {
-  color: rgba(92, 99, 112, 0.5);
+  color: #9a9a9a;
 }
 
 .settings-row-vertical {
@@ -538,14 +520,12 @@ body.capture-preparing *::after {
   margin-top: 8px;
 }
 
-/* ── Status ── */
 .status-text {
   font-size: 12px;
   color: var(--text-sub);
 }
-.status-text.error { color: #f44336; }
+.status-text.error { color: #c42b1c; }
 
-/* ── Loading dots ── */
 @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.3} }
 .dot-loading {
   display: inline-flex;
@@ -561,28 +541,24 @@ body.capture-preparing *::after {
 .dot-loading span:nth-child(2) { animation-delay: 0.2s; }
 .dot-loading span:nth-child(3) { animation-delay: 0.4s; }
 
-/* ── Overlay (kept for overlay.html) ── */
 body[data-mode="overlay"] {
   background: transparent;
   pointer-events: none;
 }
 .overlay-box {
   position: absolute;
-  background: rgba(255,255,255,0.92);
-  -webkit-backdrop-filter: blur(16px);
-  backdrop-filter: blur(16px);
-  border: 1px solid rgba(120, 160, 255, 0.3);
+  background: rgba(255,255,255,0.96);
+  border: 1px solid var(--stroke-strong);
   color: var(--text-main);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   padding: 10px 14px;
   font-size: 14px;
   line-height: 1.55;
   pointer-events: auto;
-  box-shadow: 0 8px 28px rgba(30,50,90,0.16);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.12);
   max-width: 90vw;
 }
 
-/* ── Capture window ── */
 body[data-mode="capture"] {
   background: #000;
   overflow: hidden;


### PR DESCRIPTION
On Windows, screenshots::Screen::capture() multiplies display-info sizes by scale_factor again, which breaks 100%+125% layouts. Capture with capture_area_ignore_area_check using the reported geometry instead.

Also fall back to cursor-monitor borderless fullscreen because a single softbuffer HWND spanning the virtual desktop still paints black even when the stitched RGBA is correct. Enable tauri custom-protocol so cargo build --release embeds UI instead of loading http://127.0.0.1:1420.