### PR TITLE
feat: 设置面板加「检查更新」，查到新版本一键打开发布页

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -17,7 +17,7 @@ use crate::error::{AppError, AppResult};
 use crate::models::{
     CaptureMode, CaptureRect, CaptureTranslatePayload, CaptureViewPayload, HistoryQuery,
     OcrTextResult, OverlayPayload, SelectionPayload, TextTranslationResult,
-    TranslationHistoryItem, TranslatorSettings,
+    TranslationHistoryItem, TranslatorSettings, UpdateInfo,
 };
 use crate::capture_hotkey::{decide_capture_hotkey_action, CaptureHotkeyAction};
 use crate::popup_shortcut::{decide_popup_shortcut_action, PopupShortcutAction};
@@ -218,6 +218,178 @@ pub async fn translate_text(
             proxy_url.as_deref(),
         )
         .await
+}
+
+// ── Update check ────────────────────────────────────────────────────────────
+
+/// 上游 Releases 的最新版本。查不到（离线 / 403 限流 / 非 2xx）就回 None，
+/// 前端按「这次查不了」处理，不把它当错误弹出来。
+const RELEASE_API: &str = "https://api.github.com/repos/Harukaon/Glance/releases/latest";
+/// 要打开的地址是编译期常量：`open_release_page` 不收参数，前端能影响的只有
+/// 「要不要打开」这一件事，响应里的 html_url 也不参与拼装（仓库改名或迁移会让
+/// 那条静默失效，但把外部字符串交给进程去打开这件事本身就不该做）。
+const RELEASE_PAGE_URL: &str = "https://github.com/Harukaon/Glance/releases/latest";
+/// 连不上要早点失败，但整次请求给宽一点：github.com 在国内往往要过代理，
+/// 冷启动时 DNS + TLS 加代理握手十来秒是常见的，卡 10s 会把「能查到」误判成查不到。
+const UPDATE_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(8);
+const UPDATE_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+/// 分段读超时：整体 20s 是兜底，代理半死不活时靠它早点放弃，别让连接挂着不放。
+const UPDATE_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const UPDATE_NOTES_LIMIT: usize = 600;
+const UPDATE_TAG_MAX_LEN: usize = 64;
+
+/// 把 API 返回的 tag_name 收敛成可比较的版本号：只放行 `v?数字.数字[.数字…]`
+/// 后面跟一个 `-预发布` 或 `+构建元数据` 的形状，后缀字符集限 `[0-9A-Za-z.-]`。
+/// 这个字符集里没有任何会被 shell 或 URL 解析器当断句的字符（空格 & | < > ^ " % 反引号
+/// 都不在内），所以校验过的 tag 之外不存在别的东西能进入「打开」那条路。
+/// 不合规一律 None（当这次查不了，不猜）。
+fn normalize_release_tag(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    let body = trimmed
+        .strip_prefix('v')
+        .or_else(|| trimmed.strip_prefix('V'))
+        .unwrap_or(trimmed);
+    if body.is_empty() || body.len() > UPDATE_TAG_MAX_LEN {
+        return None;
+    }
+    // 号段：至少两段纯数字（0.2 这种历史上出现过），且不能有空段。
+    let (head, suffix) = match body.find(['-', '+']) {
+        Some(index) => (&body[..index], Some(&body[index..])),
+        None => (body, None),
+    };
+    let segments: Vec<&str> = head.split('.').collect();
+    if segments.len() < 2 || segments.iter().any(|s| s.is_empty() || !s.bytes().all(|b| b.is_ascii_digit())) {
+        return None;
+    }
+    // 后缀：以 - 或 + 开头，之后只允许字母数字和 . -
+    if let Some(suffix) = suffix {
+        if suffix.len() < 2
+            || !suffix
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'.' || b == b'-' || b == b'+')
+        {
+            return None;
+        }
+    }
+    Some(body.to_ascii_lowercase())
+}
+
+/// 查一次 GitHub 上的最新 Release。代理跟翻译请求走同一套设置
+/// （ProxyMode::System / Custom），国内直连不上 GitHub 的用户不至于卡在这里。
+#[tauri::command]
+pub async fn check_update(
+    app: AppHandle,
+    state: State<'_, SharedState>,
+) -> AppResult<Option<UpdateInfo>> {
+    let proxy_url = {
+        let settings = state.settings.read().await;
+        match settings.proxy_mode {
+            crate::models::ProxyMode::None => None,
+            crate::models::ProxyMode::System => crate::builtin_translate::system_proxy_url(),
+            crate::models::ProxyMode::Custom => {
+                crate::builtin_translate::normalize_proxy(&settings.custom_proxy)
+            }
+        }
+    };
+
+    let mut builder = reqwest::Client::builder()
+        .connect_timeout(UPDATE_CONNECT_TIMEOUT)
+        .timeout(UPDATE_CHECK_TIMEOUT)
+        .read_timeout(UPDATE_READ_TIMEOUT);
+    builder = match proxy_url {
+        Some(url) => match reqwest::Proxy::all(&url) {
+            Ok(proxy) => builder.proxy(proxy),
+            // 代理串合不成一个合法 proxy 就当这次查不了：不回退成直连，
+            // 免得给用户「走了代理」的错觉，也免得国内直连必挂时白等一轮超时。
+            Err(_) => return Ok(None),
+        },
+        None => builder.no_proxy(),
+    };
+    // 构建失败就放弃这一次。不能回退到 `Client::new()`：那是个没有 connect/read/整体
+    // 超时、也不带代理的客户端，上面那三个时间上限会全部失效；而且它内部是
+    // `ClientBuilder::new().build().expect("Client::new()")`，真到了建不起来的时候
+    // 这里会从「降级」变成 panic。
+    let client = match builder.build() {
+        Ok(client) => client,
+        Err(_) => return Ok(None),
+    };
+
+    let response = match client
+        .get(RELEASE_API)
+        // GitHub 的 API 没有 User-Agent 会直接 403。
+        .header("User-Agent", "Glance")
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+    {
+        Ok(response) => response,
+        Err(_) => return Ok(None),
+    };
+    if !response.status().is_success() {
+        return Ok(None);
+    }
+    let payload: serde_json::Value = match response.json().await {
+        Ok(payload) => payload,
+        Err(_) => return Ok(None),
+    };
+
+    // tag_name 是唯一从外面进来的字符串，先过白名单；地址不用它拼（见 RELEASE_PAGE_URL）。
+    let latest = match normalize_release_tag(
+        payload.get("tag_name").and_then(|value| value.as_str()).unwrap_or(""),
+    ) {
+        Some(tag) => tag,
+        None => return Ok(None),
+    };
+    let notes = payload
+        .get("body")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .chars()
+        .take(UPDATE_NOTES_LIMIT)
+        .collect::<String>();
+    let published_at = payload
+        .get("published_at")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    Ok(Some(UpdateInfo {
+        latest,
+        current: app.package_info().version.to_string(),
+        notes,
+        published_at,
+    }))
+}
+
+/// 用系统默认浏览器打开本仓库的发布页。不收任何参数：要打开的是编译期常量，
+/// 前端与 API 响应都改不了它。
+#[tauri::command]
+pub async fn open_release_page() -> AppResult<()> {
+    open_in_browser(RELEASE_PAGE_URL)
+        .map_err(|err| AppError::Api(format!("failed to open the release page: {err}")))
+}
+
+/// 打开一个 URL。三个平台都不经过 shell：Windows 上原先那套 `cmd /C start "" <url>`
+/// 的引号是 cmd 自己的规则，Rust 的参数转义是按 MSVC argv 做的，两套对不上——
+/// 不含空格的参数 Rust 根本不加引号，`&` `|` `>` `%VAR%` 会被 cmd 当断句和展开；
+/// 带引号的参数里再塞一个 `"` 还能把引号状态翻回来。走 rundll32 的
+/// FileProtocolHandler 是同一个「按默认程序打开」入口，但没有 shell 解析器这一步。
+fn open_in_browser(url: &str) -> std::io::Result<()> {
+    #[cfg(target_os = "windows")]
+    {
+        std::process::Command::new("rundll32.exe")
+            .args(["url.dll,FileProtocolHandler", url])
+            .spawn()
+            .map(|_| ())
+    }
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open").arg(url).spawn().map(|_| ())
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        std::process::Command::new("xdg-open").arg(url).spawn().map(|_| ())
+    }
 }
 
 // ── Window ──────────────────────────────────────────────────────────────────
@@ -1313,4 +1485,56 @@ fn create_overlay_window(
     window.show()?;
     window.set_focus()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod update_tag_tests {
+    use super::normalize_release_tag;
+
+    #[test]
+    fn accepts_ordinary_tag_shapes() {
+        assert_eq!(normalize_release_tag("v0.2.30").as_deref(), Some("0.2.30"));
+        assert_eq!(normalize_release_tag("0.2.30").as_deref(), Some("0.2.30"));
+        assert_eq!(normalize_release_tag("  v0.2.30  ").as_deref(), Some("0.2.30"));
+        assert_eq!(
+            normalize_release_tag("v0.2.31-beta.2").as_deref(),
+            Some("0.2.31-beta.2")
+        );
+        assert_eq!(
+            normalize_release_tag("v1.0.0-alpha+001").as_deref(),
+            Some("1.0.0-alpha+001")
+        );
+        // 两段号历史上出现过，别当解析失败。
+        assert_eq!(normalize_release_tag("v0.2").as_deref(), Some("0.2"));
+    }
+
+    #[test]
+    fn rejects_shell_and_url_metacharacters() {
+        // 这一组是「前缀校验拦不住」的形状：都长得像 tag，但带元字符。
+        for bad in [
+            "v0.2.31&echo.pwned",
+            "v0.2.31|calc",
+            "v0.2.31>out.txt",
+            "v0.2.31^&x",
+            "v0.2.31%USERPROFILE%",
+            "v0.2.31\" & start cmd",
+            "v0.2.31 /c calc",
+            "v0.2.31`id`",
+            "v0.2.31\nrc.2",
+            "https://evil.example/x",
+            "../../etc/passwd",
+        ] {
+            assert_eq!(normalize_release_tag(bad), None, "不该放行 {:?}", bad);
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_tags() {
+        for bad in [
+            "", "   ", "v", "v.", "v..", "0..2", "0.2.", "0.2.x", "0.2.31-", "0.2.31+",
+            "nightly", "0.2.31!", "0.2.31_beta", "9".repeat(80).as_str(),
+        ] {
+            assert_eq!(normalize_release_tag(bad), None, "should reject {:?}", bad);
+        }
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -26,11 +26,10 @@ use bing_translate::BingTranslateClient;
 use builtin_translate::BuiltinTranslateClient;
 use llm_translate::LlmTranslateClient;
 use commands::{
-    begin_capture, begin_copy_capture, cancel_capture, capture_debug_log, clear_history,
-    close_overlay, hide_window, list_history, load_capture_payload, load_overlay_payload,
-    load_settings, resize_main_window, save_settings, set_pin_on_top, show_overlay,
-    submit_capture_selection,
-    translate_text,
+    begin_capture, begin_copy_capture, cancel_capture, capture_debug_log, check_update,
+    clear_history, close_overlay, hide_window, list_history, load_capture_payload,
+    load_overlay_payload, load_settings, open_release_page, resize_main_window, save_settings,
+    set_pin_on_top, show_overlay, submit_capture_selection, translate_text,
 };
 use config::ConfigStore;
 use models::TranslatorSettings;
@@ -229,7 +228,9 @@ fn main() {
             resize_main_window,
             set_pin_on_top,
             hide_window,
-            capture_debug_log
+            capture_debug_log,
+            check_update,
+            open_release_page
         ])
         .build(tauri::generate_context!())
         .expect("failed to build tauri app");

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -354,3 +354,16 @@ impl TranslationHistoryItem {
         }
     }
 }
+
+/// 一次更新检查的结果。latest 已过白名单（去 v 前缀，只留 0-9a-z.-+），谁更新交给
+/// 前端判（ui/version.mjs 里有单测），Rust 这边不做版本比较。
+/// 这里刻意没有 url 字段：要打开的地址是 commands.rs 里的常量，不让一个从前端
+/// 绕回来的字符串再去决定浏览器打开哪儿。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateInfo {
+    pub latest: String,
+    pub current: String,
+    pub notes: String,
+    pub published_at: String,
+}

--- a/ui/app.js
+++ b/ui/app.js
@@ -1,6 +1,7 @@
 import { focusTextInputIfAllowed } from "./focus-helpers.mjs";
 import { shouldTranslateOnInput, shouldTranslateOnEnter } from "./ime-guards.mjs";
 import { canRetranslateNow } from "./retranslate.mjs";
+import { isNewerVersion } from "./version.mjs";
 
 const LANGUAGES = [
   { value: "auto", label: "自动检测" },
@@ -320,6 +321,98 @@ async function ensureTauriApi() {
 async function loadSettings() { state.settings = await invoke("load_settings"); }
 async function saveSettings() { state.settings = await invoke("save_settings", { settings: state.settings }); }
 
+// 更新检查：只查 GitHub Releases 的最新 tag，比当前版本新才把按钮换成「打开下载页」。
+// 版本比较在 ui/version.mjs（有单测）。打开动作走 Rust 的 open_release_page，它不收
+// 参数、要打开的地址是 Rust 侧的常量，前端这里只负责说「打开」。
+// 启动后静默查一次，查不到（离线 / 限流）不打扰。
+//
+// 这一行的状态全收在下面几个变量里，只有 renderUpdateRow() 一处写 DOM。启动那次静默
+// 检查和用户手动点的那次可能同时在飞（静默那次走代理最长 20s），所以照 translateSeq
+// 的同一办法处理：每次检查领一个号，回来时号不是最新的那一次直接丢弃，不碰状态也不碰
+// DOM —— 否则「更早发出、更晚返回」的那次会把用户刚点出来的结果盖掉。
+let pendingUpdate = null;
+let updateChecking = false;
+let updateHint = "";
+let updateSeq = 0;
+let appVersion = "";
+let silentUpdateStarted = false;
+
+function renderUpdateRow() {
+  const btn = document.querySelector("#check-update-btn");
+  const hint = document.querySelector("#update-hint");
+  const versionEl = document.querySelector("#app-version");
+  if (versionEl) versionEl.textContent = appVersion || "-";
+  if (!btn || !hint) return;
+  btn.textContent = updateChecking ? "检查中…" : (pendingUpdate ? "打开下载页" : "检查更新");
+  btn.disabled = updateChecking;
+  btn.dataset.action = pendingUpdate ? "open" : "check";
+  hint.textContent = updateHint;
+}
+
+async function resolveAppVersion() {
+  if (appVersion) return;
+  try {
+    // getVersion 返回 Promise，不 await 就把一个 Promise 写进文本里了。
+    appVersion = (await window.__TAURI__?.app?.getVersion?.()) || "";
+  } catch (err) {
+    /* 浏览器预览里没有这个 API，留占位符 */
+  }
+  renderUpdateRow();
+}
+
+async function runUpdateCheck({ silent = false } = {}) {
+  const seq = ++updateSeq;
+  const isCurrent = () => seq === updateSeq;
+  updateChecking = true;
+  if (!silent) updateHint = "";
+  renderUpdateRow();
+
+  let info = null;
+  try {
+    info = await invoke("check_update");
+  } catch (err) {
+    if (!isCurrent()) return;
+    updateChecking = false;
+    if (!silent) updateHint = "检查失败，稍后再试";
+    renderUpdateRow();
+    return;
+  }
+  if (!isCurrent()) return;
+
+  updateChecking = false;
+  if (info && info.current) appVersion = info.current;
+  if (info && isNewerVersion(info.latest, info.current)) {
+    pendingUpdate = info;
+    // 静默那次也要把「有新版本」写在提示里：这行本来就是给用户看的。
+    updateHint = "有新版本 " + info.latest;
+  } else {
+    pendingUpdate = null;
+    if (!silent) updateHint = info ? "已是最新" : "查不到，稍后再试";
+  }
+  renderUpdateRow();
+}
+
+function bindUpdateRow() {
+  const btn = document.querySelector("#check-update-btn");
+  if (!btn) return;
+  btn.addEventListener("click", e => {
+    e.stopPropagation();
+    if (e.currentTarget.dataset.action === "open") {
+      invoke("open_release_page").catch(() => {});
+      return;
+    }
+    if (!updateChecking) runUpdateCheck();
+  });
+  // renderMain() 会整块换掉 innerHTML，所以每次重渲染都要把状态补回新节点，
+  // 而不是等下一次检查才把「打开下载页」显示出来。
+  renderUpdateRow();
+  resolveAppVersion();
+  if (!silentUpdateStarted) {
+    silentUpdateStarted = true;
+    runUpdateCheck({ silent: true });
+  }
+}
+
 async function bindMainListeners() {
   if (state.listenersBound || mode !== "main") return;
   if (!listen) {
@@ -435,6 +528,14 @@ function renderMain() {
               ${state.settings.popupShortcut ? shortcutKeysHtml(state.settings.popupShortcut) : "未设置"} <span class="shortcut-hint">点击可设置</span>
             </div>
           </div>
+          <div class="settings-row">
+            <span class="settings-label">版本</span>
+            <div class="update-row">
+              <span class="settings-hint" id="app-version">-</span>
+              <button type="button" class="update-btn" id="check-update-btn">检查更新</button>
+              <span class="settings-hint" id="update-hint"></span>
+            </div>
+          </div>
         </div>
         <div class="settings-section" id="llm-settings" style="${state.settings.textTranslateEngine === "llm" ? "" : "display:none"}">
           <div class="settings-row">
@@ -538,6 +639,9 @@ function renderMain() {
     saveSettings().catch(() => {});
   });
   document.querySelector("#tts-btn").addEventListener("click", speakInput);
+
+  // 版本 / 检查更新
+  bindUpdateRow();
 
   // 置顶：状态从 settings 走，按钮高亮和窗口实际 topmost 都由 applyPin 同步。
   document.querySelector("#pin-btn").addEventListener("click", e => {

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -502,6 +502,31 @@ body.capture-preparing *::after {
   font-weight: 400;
   color: var(--text-sub);
 }
+/* 更新行：当前版本 + 一个按钮（查到新版时变成「打开下载页」）。 */
+.update-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.update-btn {
+  background: none;
+  border: 1px solid var(--block-bg);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-main);
+  padding: 3px 10px;
+  border-radius: 6px;
+  white-space: nowrap;
+}
+.update-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.update-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
 .settings-textarea {
   width: 100%;
   margin-left: 0;

--- a/ui/version.mjs
+++ b/ui/version.mjs
@@ -1,0 +1,71 @@
+// 版本号比较。Release tag 形如 `v0.2.30`，也可能带后缀（`0.2.31-beta.1`、`0.2.31+build.5`）。
+// 「有没有新版本」这件事放在前端判：Rust 的 check_update 只把 GitHub 上的最新 tag
+// 与当前版本原样带回来，判定逻辑在这里，能用 node --test 单独测。
+//
+// 按 SemVer 2.0 的优先级规则来（https://semver.org/）：
+//   1. 数字段逐段按整数比，不是字典序（`0.2.10` 比 `0.2.9` 新）；
+//   2. 带预发布号的比同号正式版旧（`0.2.31-beta` < `0.2.31`）；
+//   3. 预发布号按 `.` 拆段逐段比：纯数字段按整数比（`beta.10` 比 `beta.2` 新），
+//      数字段排在字母段之前，逐段相等时段数少的算更旧；
+//   4. `+build` 是构建元数据，不参与优先级（`0.2.31+build.5` 与 `0.2.31` 视为同一版）。
+// 比 SemVer 松的地方只有一处：允许 `v` 前缀，且数字段可以多于或少于 3 段（缺的按 0 补），
+// 因为包里 version 字段历史上出现过 `0.2` 这种写法，别把它判成解析失败。
+
+const VERSION_RE = /^v?(\d+(?:\.\d+)*)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$/;
+
+export function parseVersion(raw) {
+  const text = typeof raw === "string" ? raw.trim() : "";
+  const match = VERSION_RE.exec(text);
+  if (!match) return null;
+  return {
+    numbers: match[1].split(".").map(n => Number.parseInt(n, 10)),
+    prerelease: match[2] ? match[2].split(".") : [],
+    build: match[3] || "",
+  };
+}
+
+// 预发布的单段比较：纯数字段按整数比，且永远排在字母段前面。
+function comparePrereleasePart(a, b) {
+  const aNumeric = /^\d+$/.test(a);
+  const bNumeric = /^\d+$/.test(b);
+  if (aNumeric && bNumeric) return Number(a) - Number(b);
+  if (aNumeric) return -1;
+  if (bNumeric) return 1;
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+}
+
+function comparePrerelease(a, b) {
+  // 没有预发布号的那一边更新（0.2.31 > 0.2.31-beta）。
+  if (a.length === 0 || b.length === 0) {
+    if (a.length === b.length) return 0;
+    return a.length === 0 ? 1 : -1;
+  }
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    if (a[i] === undefined) return -1;
+    if (b[i] === undefined) return 1;
+    const diff = comparePrereleasePart(a[i], b[i]);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+// 返回 >0 / 0 / <0，读作「a 比 b 更新 / 同级 / 更旧」。
+// 有一边解析不出来就按 0 处理，调用方据此不会报「有新版本」。
+export function compareVersions(a, b) {
+  const va = parseVersion(a);
+  const vb = parseVersion(b);
+  if (!va || !vb) return 0;
+  const len = Math.max(va.numbers.length, vb.numbers.length);
+  for (let i = 0; i < len; i++) {
+    const x = va.numbers[i] || 0;
+    const y = vb.numbers[i] || 0;
+    if (x !== y) return x - y;
+  }
+  return comparePrerelease(va.prerelease, vb.prerelease);
+}
+
+export function isNewerVersion(latest, current) {
+  return compareVersions(latest, current) > 0;
+}

--- a/ui/version.test.mjs
+++ b/ui/version.test.mjs
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { compareVersions, isNewerVersion, parseVersion } from "./version.mjs";
+
+test("按数字段比，不是按字符串比", () => {
+  assert.equal(isNewerVersion("0.2.10", "0.2.9"), true);
+  assert.equal(isNewerVersion("0.2.9", "0.2.10"), false);
+  assert.equal(isNewerVersion("0.10.0", "0.9.9"), true);
+  assert.equal(isNewerVersion("1.0.0", "0.99.99"), true);
+});
+
+test("相同版本不算有新版本", () => {
+  assert.equal(isNewerVersion("0.2.30", "0.2.30"), false);
+  assert.equal(isNewerVersion("v0.2.30", "0.2.30"), false);
+  assert.equal(isNewerVersion("0.2", "0.2.0"), false);
+  assert.equal(isNewerVersion("0.2.0.0", "0.2"), false);
+});
+
+test("带后缀的比同号正式版旧", () => {
+  assert.equal(isNewerVersion("0.2.31-beta.1", "0.2.30"), true);
+  assert.equal(isNewerVersion("0.2.30", "0.2.30-beta.1"), true);
+  assert.equal(isNewerVersion("0.2.30-beta.1", "0.2.30"), false);
+  assert.equal(isNewerVersion("0.2.30-beta.2", "0.2.30-beta.1"), true);
+});
+
+test("预发布段按整数比，不是字典序", () => {
+  // beta.10 比 beta.2 新；字典序会把它判反。
+  assert.equal(isNewerVersion("0.2.31-beta.10", "0.2.31-beta.2"), true);
+  assert.equal(isNewerVersion("0.2.31-beta.2", "0.2.31-beta.10"), false);
+  assert.equal(isNewerVersion("0.2.31-2", "0.2.31-10"), false);
+  // 纯数字段永远排在字母段前面。
+  assert.equal(isNewerVersion("0.2.31-alpha", "0.2.31-1"), true);
+  assert.equal(isNewerVersion("0.2.31-1", "0.2.31-alpha"), false);
+  // 逐段相等时段数少的更旧。
+  assert.equal(isNewerVersion("0.2.31-beta.1.0", "0.2.31-beta.1"), true);
+  assert.equal(isNewerVersion("0.2.31-beta.1", "0.2.31-beta.1.0"), false);
+});
+
+test("+build 是构建元数据，不参与优先级", () => {
+  assert.equal(isNewerVersion("0.2.31+build.5", "0.2.31"), false);
+  assert.equal(isNewerVersion("0.2.31", "0.2.31+build.5"), false);
+  assert.equal(isNewerVersion("0.2.31+build.9", "0.2.31+build.2"), false);
+  // 只差构建元数据的 tag 不该提示有新版本，但号真的更新了要能报出来。
+  assert.equal(isNewerVersion("0.2.32+build.1", "0.2.31+build.9"), true);
+  assert.equal(compareVersions("0.2.31+build.5", "0.2.31"), 0);
+  // 预发布 + 构建元数据混在一起时，只有预发布参与比较。
+  assert.equal(isNewerVersion("0.2.31-alpha+001", "0.2.31-alpha"), false);
+  assert.equal(isNewerVersion("0.2.31-alpha+002", "0.2.31-alpha+001"), false);
+});
+
+test("解析不出来的一律按没有新版本处理", () => {
+  assert.equal(isNewerVersion("", "0.2.30"), false);
+  assert.equal(isNewerVersion("latest", "0.2.30"), false);
+  assert.equal(isNewerVersion("0.2.31", ""), false);
+  assert.equal(isNewerVersion(undefined, undefined), false);
+  assert.equal(isNewerVersion("0.2.31-beta!", "0.2.30"), false);
+  assert.equal(parseVersion("nightly"), null);
+  assert.deepEqual(parseVersion("v0.2.30"), { numbers: [0, 2, 30], prerelease: [], build: "" });
+  assert.deepEqual(parseVersion("0.2.31-beta.2+build.7"), {
+    numbers: [0, 2, 31], prerelease: ["beta", "2"], build: "build.7",
+  });
+});


### PR DESCRIPTION
装完之后想知道有没有新版，只能自己来 Releases 翻，所以加了这一行。

设置面板最下面多一行「版本 0.2.30 · 检查更新」：启动后静默查一次 GitHub Releases 的最新 tag，比当前版本新就把按钮换成「打开下载页」，点一下用系统默认浏览器打开。查不到（离线、403 限流、非 2xx）一律当「这次查不了」处理，不弹错。

Rust 侧两个命令：`check_update` 用项目里已有的 reqwest（没加依赖），代理跟着翻译请求那套设置走（System / Custom），连接 8s、整次请求 20s —— github.com 在国内常要过代理，冷启动时 DNS + TLS + 代理握手十来秒是常态，卡太紧会把「能查到」误判成查不到；`open_release_page` 只放行本仓库的 GitHub 地址，免得这个命令变成任意 URL 打开器。版本比较放在 `ui/version.mjs` 的 `isNewerVersion`：数字段逐位比（`0.2.10` > `0.2.9`），同号时带后缀的算更旧（`0.2.31-beta` < `0.2.31`），带 4 条 `node --test`。

没有用 `tauri-plugin-updater`：那套要生成 minisign 私钥存进 CI secret、发布时还要多一个 `latest.json`，先做不需要动密钥的那一半。真要应用内下载安装，再单独谈。

验证：`node --test ui/version.test.mjs ui/ime-guards.test.mjs ui/focus-helpers.test.mjs` 14 pass；无头桩覆盖「有新版本 / 已是最新 / 查不到」三种返回；真机上拿官方 0.2.30 那个包点检查更新是「已是最新」（本机实测 0.5s 回来），把版本号临时降到 0.2.29 重新构建后能报「有新版本 0.2.30」并且真的打开了发布页，拿 `https://example.com/` 调 `open_release_page` 会被拒。
